### PR TITLE
Add recording delete menu option

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             storage::storage_list_recordings,
             storage::storage_get_recording,
             storage::storage_save_recording,
+            storage::storage_delete_recording,
             storage::storage_read_text,
             storage::storage_write_attachment_text
         ])

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -366,6 +366,24 @@ pub fn storage_save_recording(app: AppHandle, recording: Recording) -> Result<()
 }
 
 #[tauri::command]
+pub fn storage_delete_recording(app: AppHandle, recording_id: String) -> Result<(), String> {
+    if !is_safe_id(&recording_id) {
+        return Err("Invalid recording id".to_string());
+    }
+
+    let paths = storage_paths(&app)?;
+    ensure_storage(&paths)?;
+
+    let dir_path = recording_dir(&paths, &recording_id);
+    if !dir_path.exists() {
+        return Ok(());
+    }
+
+    fs::remove_dir_all(&dir_path).map_err(err_to_string)?;
+    Ok(())
+}
+
+#[tauri::command]
 pub fn storage_read_text(app: AppHandle, path: String) -> Result<String, String> {
     if !is_safe_relative_path(&path) || !path.starts_with("recordings/") {
         return Err("Invalid path".to_string());

--- a/src/app/list/index.ts
+++ b/src/app/list/index.ts
@@ -15,6 +15,7 @@ export class ListController {
   private readonly onSelect: (recordingId: string) => void;
   private listening = false;
   private refreshSeq = 0;
+  private itemDisposers: Array<() => void> = [];
   private readonly onChanged = (): void => {
     void this.refresh();
   };
@@ -38,6 +39,7 @@ export class ListController {
       document.removeEventListener(RECORDINGS_CHANGED_EVENT, this.onChanged);
       this.listening = false;
     }
+    this.teardownItems();
   }
 
   async refresh(): Promise<void> {
@@ -49,6 +51,7 @@ export class ListController {
     } catch (error) {
       if (seq !== this.refreshSeq) return;
       const message = error instanceof Error ? error.message : String(error);
+      this.teardownItems();
       this.container.textContent = `Failed to load recordings: ${message}`;
       return;
     }
@@ -56,25 +59,69 @@ export class ListController {
     if (seq !== this.refreshSeq) return;
 
     if (summaries.length === 0) {
+      this.teardownItems();
       this.container.replaceChildren(renderEmptyState());
       return;
     }
 
-    this.container.replaceChildren(
-      ...summaries.map((summary) => renderItem(summary, this.onSelect)),
+    const rendered = summaries.map((summary) =>
+      renderItem({
+        summary,
+        onSelect: this.onSelect,
+        onDelete: (recordingId) => this.deleteRecording(recordingId),
+      }),
     );
+
+    this.teardownItems();
+    this.itemDisposers = rendered.map((item) => item.dispose);
+    this.container.replaceChildren(...rendered.map((item) => item.element));
+  }
+
+  private teardownItems(): void {
+    for (const dispose of this.itemDisposers) {
+      dispose();
+    }
+    this.itemDisposers = [];
+  }
+
+  private async deleteRecording(recordingId: string): Promise<void> {
+    try {
+      await this.store.deleteRecording(recordingId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      window.alert(`Failed to delete recording: ${message}`);
+      return;
+    }
+
+    fireRecordingsChanged();
+    if (!this.listening) {
+      await this.refresh();
+    }
   }
 }
 
-function renderItem(
-  summary: RecordingSummary,
-  onSelect: (recordingId: string) => void,
-): HTMLElement {
-  const el = document.createElement("button");
-  el.type = "button";
-  el.className = "recording-item";
-  el.dataset.recordingId = summary.recordingId;
-  el.addEventListener("click", () => {
+interface RenderItemOptions {
+  summary: RecordingSummary;
+  onSelect: (recordingId: string) => void;
+  onDelete: (recordingId: string) => void | Promise<void>;
+}
+
+interface RenderedItem {
+  element: HTMLElement;
+  dispose: () => void;
+}
+
+function renderItem(options: RenderItemOptions): RenderedItem {
+  const { summary, onSelect, onDelete } = options;
+
+  const element = document.createElement("div");
+  element.className = "recording-item";
+  element.dataset.recordingId = summary.recordingId;
+
+  const main = document.createElement("button");
+  main.type = "button";
+  main.className = "recording-item-main";
+  main.addEventListener("click", () => {
     onSelect(summary.recordingId);
   });
 
@@ -87,8 +134,100 @@ function renderItem(
   const n = summary.attachmentCount;
   count.textContent = `${n} attachment${n === 1 ? "" : "s"}`;
 
-  el.append(date, count);
-  return el;
+  main.append(date, count);
+
+  const actionWrap = document.createElement("div");
+  actionWrap.className = "recording-item-actions";
+
+  const selector = document.createElement("button");
+  selector.type = "button";
+  selector.className = "recording-item-selector";
+  selector.setAttribute("aria-haspopup", "menu");
+  selector.setAttribute("aria-expanded", "false");
+  selector.setAttribute("aria-label", "Open recording menu");
+  selector.textContent = "...";
+
+  const menu = document.createElement("div");
+  menu.className = "recording-item-menu";
+  menu.setAttribute("role", "menu");
+  menu.hidden = true;
+
+  const deleteButton = document.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "recording-item-menu-item";
+  deleteButton.textContent = "Delete";
+  deleteButton.setAttribute("role", "menuitem");
+  menu.append(deleteButton);
+
+  let menuOpen = false;
+  let deletePending = false;
+  let removeDocClick: (() => void) | null = null;
+
+  const closeMenu = (): void => {
+    if (!menuOpen) return;
+    menuOpen = false;
+    menu.hidden = true;
+    selector.setAttribute("aria-expanded", "false");
+    removeDocClick?.();
+    removeDocClick = null;
+  };
+
+  const openMenu = (): void => {
+    if (menuOpen) return;
+    menuOpen = true;
+    menu.hidden = false;
+    selector.setAttribute("aria-expanded", "true");
+
+    const onDocumentClick = (event: MouseEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (element.contains(target)) return;
+      closeMenu();
+    };
+
+    document.addEventListener("click", onDocumentClick);
+    removeDocClick = () => {
+      document.removeEventListener("click", onDocumentClick);
+    };
+  };
+
+  selector.addEventListener("click", (event) => {
+    event.stopPropagation();
+    if (menuOpen) {
+      closeMenu();
+      return;
+    }
+    openMenu();
+  });
+
+  deleteButton.addEventListener("click", (event) => {
+    event.stopPropagation();
+    if (deletePending) {
+      return;
+    }
+    closeMenu();
+    deletePending = true;
+    deleteButton.disabled = true;
+
+    void (async () => {
+      const confirmed = await confirmDelete();
+      if (!confirmed) {
+        return;
+      }
+      await onDelete(summary.recordingId);
+    })().finally(() => {
+      deletePending = false;
+      deleteButton.disabled = false;
+    });
+  });
+
+  actionWrap.append(selector, menu);
+  element.append(main, actionWrap);
+
+  return {
+    element,
+    dispose: closeMenu,
+  };
 }
 
 function formatDate(iso: string): string {
@@ -115,4 +254,30 @@ function renderEmptyState(): HTMLElement {
 
 export function fireRecordingsChanged(): void {
   document.dispatchEvent(new CustomEvent(RECORDINGS_CHANGED_EVENT));
+}
+
+async function confirmDelete(): Promise<boolean> {
+  const confirmFn = window.confirm as unknown as (message?: string) => unknown;
+  const value = confirmFn("Delete this recording?");
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (isPromiseLike(value)) {
+    try {
+      return Boolean(await value);
+    } catch {
+      return false;
+    }
+  }
+  return Boolean(value);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("then" in value)) {
+    return false;
+  }
+  return typeof (value as { then?: unknown }).then === "function";
 }

--- a/src/app/list/list-controller.test.ts
+++ b/src/app/list/list-controller.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 import { NoopRecordingStore } from "../../storage/noop-store";
 import type { RecordingService } from "../recording-service";
@@ -23,6 +23,7 @@ describe("ListController", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     container.remove();
   });
 
@@ -100,11 +101,127 @@ describe("ListController", () => {
     });
     await ctrl.refresh();
 
-    const first = container.querySelector<HTMLButtonElement>(".recording-item");
+    const first = container.querySelector<HTMLButtonElement>(
+      ".recording-item-main",
+    );
     expect(first).not.toBeNull();
     first?.click();
 
     expect(selectedId).not.toBeNull();
+  });
+
+  it("opens the selector menu and closes on outside click", async () => {
+    const store = new NoopRecordingStore();
+    const { RecordingService } = await import("../recording-service");
+    const service = new RecordingService(store);
+    await saveInNewRecording(service, "A note");
+
+    const ctrl = new ListController({ container, store });
+    await ctrl.refresh();
+
+    const selector = container.querySelector<HTMLButtonElement>(
+      ".recording-item-selector",
+    );
+    const menu = container.querySelector<HTMLElement>(".recording-item-menu");
+    expect(selector).not.toBeNull();
+    expect(menu).not.toBeNull();
+    expect(menu?.hidden).toBe(true);
+
+    selector?.click();
+    expect(menu?.hidden).toBe(false);
+
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(menu?.hidden).toBe(true);
+  });
+
+  it("asks for delete confirmation and removes recording on confirm", async () => {
+    const store = new NoopRecordingStore();
+    const { RecordingService } = await import("../recording-service");
+    const service = new RecordingService(store);
+    await saveInNewRecording(service, "A note");
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const ctrl = new ListController({ container, store });
+    await ctrl.refresh();
+
+    const selector = container.querySelector<HTMLButtonElement>(
+      ".recording-item-selector",
+    );
+    selector?.click();
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      ".recording-item-menu-item",
+    );
+    deleteButton?.click();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(confirmSpy).toHaveBeenCalledWith("Delete this recording?");
+    expect(container.querySelector(".empty-state")).not.toBeNull();
+  });
+
+  it("keeps recording when delete confirmation is canceled", async () => {
+    const store = new NoopRecordingStore();
+    const { RecordingService } = await import("../recording-service");
+    const service = new RecordingService(store);
+    await saveInNewRecording(service, "A note");
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    const ctrl = new ListController({ container, store });
+    await ctrl.refresh();
+
+    const selector = container.querySelector<HTMLButtonElement>(
+      ".recording-item-selector",
+    );
+    selector?.click();
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      ".recording-item-menu-item",
+    );
+    deleteButton?.click();
+    await flushMicrotasks();
+
+    expect(confirmSpy).toHaveBeenCalledWith("Delete this recording?");
+    expect(container.querySelectorAll(".recording-item")).toHaveLength(1);
+  });
+
+  it("waits for async confirmation before deleting", async () => {
+    const store = new NoopRecordingStore();
+    const { RecordingService } = await import("../recording-service");
+    const service = new RecordingService(store);
+    await saveInNewRecording(service, "A note");
+
+    const gate = deferred<boolean>();
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockImplementation(
+        (() => gate.promise) as unknown as typeof window.confirm,
+      );
+
+    const ctrl = new ListController({ container, store });
+    await ctrl.refresh();
+
+    const selector = container.querySelector<HTMLButtonElement>(
+      ".recording-item-selector",
+    );
+    selector?.click();
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      ".recording-item-menu-item",
+    );
+    deleteButton?.click();
+    await flushMicrotasks();
+
+    expect(confirmSpy).toHaveBeenCalledWith("Delete this recording?");
+    expect(container.querySelectorAll(".recording-item")).toHaveLength(1);
+
+    gate.resolve(true);
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(container.querySelector(".empty-state")).not.toBeNull();
   });
 
   it("stops listening after unmount", async () => {

--- a/src/storage/noop-store.ts
+++ b/src/storage/noop-store.ts
@@ -45,6 +45,17 @@ export class NoopRecordingStore implements RecordingStore {
     this.recordings.set(recording.recordingId, recording);
   }
 
+  async deleteRecording(recordingId: string): Promise<void> {
+    this.recordings.delete(recordingId);
+
+    const attachmentPrefix = `recordings/${recordingId}/attachments/`;
+    for (const path of this.textByPath.keys()) {
+      if (path.startsWith(attachmentPrefix)) {
+        this.textByPath.delete(path);
+      }
+    }
+  }
+
   async readText(path: string): Promise<string> {
     const text = this.textByPath.get(path);
     if (text === undefined) {

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -24,6 +24,7 @@ export interface RecordingStore {
   listRecordings(): Promise<RecordingSummary[]>;
   getRecording(recordingId: string): Promise<Recording | null>;
   saveRecording(recording: Recording): Promise<void>;
+  deleteRecording(recordingId: string): Promise<void>;
   readText(path: string): Promise<string>;
   writeAttachmentText(
     input: WriteAttachmentTextInput,

--- a/src/storage/tauri-store.ts
+++ b/src/storage/tauri-store.ts
@@ -29,6 +29,10 @@ export class TauriRecordingStore implements RecordingStore {
     return invoke<void>("storage_save_recording", { recording });
   }
 
+  deleteRecording(recordingId: string): Promise<void> {
+    return invoke<void>("storage_delete_recording", { recordingId });
+  }
+
   readText(path: string): Promise<string> {
     return invoke<string>("storage_read_text", { path });
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -315,7 +315,6 @@ body {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  margin-bottom: var(--space-3);
   cursor: pointer;
   transition: background 0.15s ease;
 }
@@ -412,7 +411,6 @@ body {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  margin-bottom: var(--space-3);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -938,13 +936,20 @@ body {
 .recording-item {
   display: flex;
   align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.recording-item-main {
+  display: flex;
+  align-items: center;
   justify-content: space-between;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: var(--space-4);
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  margin-bottom: var(--space-3);
   cursor: pointer;
   transition: background 0.15s ease;
   font-family: inherit;
@@ -952,7 +957,57 @@ body {
   text-align: left;
 }
 
-.recording-item:active {
+.recording-item-main:active {
+  background: var(--bg-secondary);
+}
+
+.recording-item-actions {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.recording-item-selector {
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.recording-item-selector:active {
+  background: var(--bg-secondary);
+}
+
+.recording-item-menu {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  right: 0;
+  min-width: 120px;
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  z-index: 20;
+}
+
+.recording-item-menu-item {
+  width: 100%;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--error);
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.recording-item-menu-item:active {
   background: var(--bg-secondary);
 }
 


### PR DESCRIPTION
## Summary
- expose a `storage_delete_recording` Tauri command and hook it up to the shared store interface
- refresh the list and clean up listeners after rendering recording items
- add a selector menu for each recording with a confirm-before-delete flow and tests covering menu behavior

## Testing
- Not run (not requested)