### PR TITLE
Add recording export notification and latest zip support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "ureq 2.12.1",
+ "zip",
 ]
 
 [[package]]
@@ -972,6 +973,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4509,6 +4511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5753,10 +5761,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e499faf5c6b97a0d086f4a8733de6d47aee2252b8127962439d8d4311a73f72"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+
+[[package]]
 name = "zmij"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ ureq = { version = "2", default-features = false, features = ["json"] }
 ort = "2.0.0-rc.11"
 ndarray = "0.16"
 realfft = "3"
+zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [[bin]]
 name = "benchmark-asr"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,7 @@ pub fn run() {
             storage::storage_get_recording,
             storage::storage_save_recording,
             storage::storage_delete_recording,
+            storage::storage_export_recording,
             storage::storage_read_text,
             storage::storage_write_attachment_text
         ])

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -5,6 +5,8 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager};
+use zip::write::SimpleFileOptions;
+use zip::CompressionMethod;
 
 const STORAGE_FORMAT: u8 = 1;
 const RECORDING_FILE_NAME: &str = "recording.json";
@@ -303,6 +305,105 @@ fn list_recording_entries_from_files(paths: &StoragePaths) -> Result<Vec<Recordi
     Ok(recordings)
 }
 
+fn read_dir_sorted(path: &Path) -> Result<Vec<fs::DirEntry>, String> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(path).map_err(err_to_string)? {
+        entries.push(entry.map_err(err_to_string)?);
+    }
+    entries.sort_by(|left, right| left.file_name().cmp(&right.file_name()));
+    Ok(entries)
+}
+
+fn to_zip_path(base: &Path, path: &Path) -> Result<String, String> {
+    let relative = path.strip_prefix(base).map_err(err_to_string)?;
+    let value = relative.to_string_lossy().replace('\\', "/");
+    if value.is_empty() {
+        return Err("Invalid export entry path".to_string());
+    }
+    Ok(value)
+}
+
+fn append_directory_to_zip(
+    zip: &mut zip::ZipWriter<File>,
+    source_root: &Path,
+    current_dir: &Path,
+    file_options: SimpleFileOptions,
+    dir_options: SimpleFileOptions,
+) -> Result<(), String> {
+    for entry in read_dir_sorted(current_dir)? {
+        let entry_path = entry.path();
+        let entry_type = entry.file_type().map_err(err_to_string)?;
+
+        if entry_type.is_symlink() {
+            continue;
+        }
+
+        if entry_type.is_dir() {
+            let zip_path = to_zip_path(source_root, &entry_path)?;
+            zip.add_directory(format!("{zip_path}/"), dir_options.clone())
+                .map_err(err_to_string)?;
+            append_directory_to_zip(
+                zip,
+                source_root,
+                &entry_path,
+                file_options.clone(),
+                dir_options.clone(),
+            )?;
+            continue;
+        }
+
+        if entry_type.is_file() {
+            let zip_path = to_zip_path(source_root, &entry_path)?;
+            zip.start_file(zip_path, file_options.clone())
+                .map_err(err_to_string)?;
+            let mut source_file = File::open(&entry_path).map_err(err_to_string)?;
+            io::copy(&mut source_file, zip).map_err(err_to_string)?;
+            continue;
+        }
+
+        return Err("Unsupported file type in recording directory".to_string());
+    }
+
+    Ok(())
+}
+
+fn export_directory_to_zip(source_dir: &Path, destination_path: &Path) -> Result<(), String> {
+    let output_file = File::create(destination_path).map_err(err_to_string)?;
+    let mut zip = zip::ZipWriter::new(output_file);
+    let file_options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    let dir_options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .unix_permissions(0o755);
+
+    append_directory_to_zip(&mut zip, source_dir, source_dir, file_options, dir_options)?;
+    zip.finish().map_err(err_to_string)?;
+    Ok(())
+}
+
+fn sanitize_export_destination(destination_path: &str) -> Result<PathBuf, String> {
+    let trimmed = destination_path.trim();
+    if trimmed.is_empty() {
+        return Err("Invalid destination path".to_string());
+    }
+
+    let parsed = PathBuf::from(trimmed);
+    if !parsed.is_absolute() {
+        return Err("Destination path must be absolute".to_string());
+    }
+
+    let Some(file_name) = parsed.file_name().and_then(|value| value.to_str()) else {
+        return Err("Invalid destination file name".to_string());
+    };
+
+    if file_name.is_empty() {
+        return Err("Invalid destination file name".to_string());
+    }
+
+    Ok(parsed)
+}
+
 #[tauri::command]
 pub fn storage_init(app: AppHandle) -> Result<StorageInitResult, String> {
     let paths = storage_paths(&app)?;
@@ -380,6 +481,39 @@ pub fn storage_delete_recording(app: AppHandle, recording_id: String) -> Result<
     }
 
     fs::remove_dir_all(&dir_path).map_err(err_to_string)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn storage_export_recording(
+    app: AppHandle,
+    recording_id: String,
+    destination_path: String,
+) -> Result<(), String> {
+    if !is_safe_id(&recording_id) {
+        return Err("Invalid recording id".to_string());
+    }
+
+    let destination_path = sanitize_export_destination(&destination_path)?;
+    let paths = storage_paths(&app)?;
+    ensure_storage(&paths)?;
+
+    let source_dir = recording_dir(&paths, &recording_id);
+    if !source_dir.exists() {
+        return Err("Recording not found".to_string());
+    }
+    if !source_dir.is_dir() {
+        return Err("Recording directory is invalid".to_string());
+    }
+    if destination_path.starts_with(&source_dir) {
+        return Err("Destination path cannot be inside the recording directory".to_string());
+    }
+
+    let Some(parent_dir) = destination_path.parent() else {
+        return Err("Invalid destination path".to_string());
+    };
+    fs::create_dir_all(parent_dir).map_err(err_to_string)?;
+    export_directory_to_zip(&source_dir, &destination_path)?;
     Ok(())
 }
 

--- a/src/app/list/index.ts
+++ b/src/app/list/index.ts
@@ -13,6 +13,7 @@ export class ListController {
   private readonly container: HTMLElement;
   private readonly store: RecordingStore;
   private readonly onSelect: (recordingId: string) => void;
+  private readonly canExportRecordings: boolean;
   private listening = false;
   private refreshSeq = 0;
   private itemDisposers: Array<() => void> = [];
@@ -24,6 +25,7 @@ export class ListController {
     this.container = options.container;
     this.store = options.store;
     this.onSelect = options.onSelect ?? (() => undefined);
+    this.canExportRecordings = this.store.canExportRecordings();
   }
 
   mount(): void {
@@ -67,7 +69,10 @@ export class ListController {
     const rendered = summaries.map((summary) =>
       renderItem({
         summary,
+        canExport: this.canExportRecordings,
         onSelect: this.onSelect,
+        onExport: (recordingId, createdAt) =>
+          this.exportRecording(recordingId, createdAt),
         onDelete: (recordingId) => this.deleteRecording(recordingId),
       }),
     );
@@ -98,11 +103,39 @@ export class ListController {
       await this.refresh();
     }
   }
+
+  private async exportRecording(
+    recordingId: string,
+    createdAt: string,
+  ): Promise<void> {
+    let destinationPath: string | null;
+    try {
+      destinationPath = await pickExportPath(createdAt);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      window.alert(`Failed to open export dialog: ${message}`);
+      return;
+    }
+
+    if (!destinationPath) {
+      return;
+    }
+
+    try {
+      await this.store.exportRecording(recordingId, destinationPath);
+      await notifyExportSuccess(destinationPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      window.alert(`Failed to export recording: ${message}`);
+    }
+  }
 }
 
 interface RenderItemOptions {
   summary: RecordingSummary;
+  canExport: boolean;
   onSelect: (recordingId: string) => void;
+  onExport: (recordingId: string, createdAt: string) => void | Promise<void>;
   onDelete: (recordingId: string) => void | Promise<void>;
 }
 
@@ -112,7 +145,7 @@ interface RenderedItem {
 }
 
 function renderItem(options: RenderItemOptions): RenderedItem {
-  const { summary, onSelect, onDelete } = options;
+  const { summary, canExport, onSelect, onExport, onDelete } = options;
 
   const element = document.createElement("div");
   element.className = "recording-item";
@@ -152,14 +185,26 @@ function renderItem(options: RenderItemOptions): RenderedItem {
   menu.setAttribute("role", "menu");
   menu.hidden = true;
 
+  let exportButton: HTMLButtonElement | null = null;
+  if (canExport) {
+    exportButton = document.createElement("button");
+    exportButton.type = "button";
+    exportButton.className = "recording-item-menu-item";
+    exportButton.textContent = "Export";
+    exportButton.setAttribute("role", "menuitem");
+    menu.append(exportButton);
+  }
+
   const deleteButton = document.createElement("button");
   deleteButton.type = "button";
-  deleteButton.className = "recording-item-menu-item";
+  deleteButton.className =
+    "recording-item-menu-item recording-item-menu-item-destructive";
   deleteButton.textContent = "Delete";
   deleteButton.setAttribute("role", "menuitem");
   menu.append(deleteButton);
 
   let menuOpen = false;
+  let exportPending = false;
   let deletePending = false;
   let removeDocClick: (() => void) | null = null;
 
@@ -200,6 +245,26 @@ function renderItem(options: RenderItemOptions): RenderedItem {
     openMenu();
   });
 
+  if (exportButton) {
+    const button = exportButton;
+    button.addEventListener("click", (event) => {
+      event.stopPropagation();
+      if (exportPending) {
+        return;
+      }
+      closeMenu();
+      exportPending = true;
+      button.disabled = true;
+
+      void Promise.resolve(
+        onExport(summary.recordingId, summary.createdAt),
+      ).finally(() => {
+        exportPending = false;
+        button.disabled = false;
+      });
+    });
+  }
+
   deleteButton.addEventListener("click", (event) => {
     event.stopPropagation();
     if (deletePending) {
@@ -228,6 +293,55 @@ function renderItem(options: RenderItemOptions): RenderedItem {
     element,
     dispose: closeMenu,
   };
+}
+
+async function pickExportPath(createdAt: string): Promise<string | null> {
+  const { save } = await import("@tauri-apps/plugin-dialog");
+  const selected = await save({
+    title: "Export Recording Session",
+    defaultPath: `${formatDateFilename(createdAt)}.zip`,
+    filters: [{ name: "Zip Archive", extensions: ["zip"] }],
+  });
+  if (typeof selected !== "string") {
+    return null;
+  }
+  const trimmed = selected.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return ensureZipExtension(trimmed);
+}
+
+function ensureZipExtension(path: string): string {
+  if (path.toLowerCase().endsWith(".zip")) {
+    return path;
+  }
+  return `${path}.zip`;
+}
+
+function formatDateFilename(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "recording";
+  }
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${d}_${hh}-${mm}`;
+}
+
+async function notifyExportSuccess(destinationPath: string): Promise<void> {
+  try {
+    const { message } = await import("@tauri-apps/plugin-dialog");
+    await message(`Exported to ${destinationPath}`, {
+      title: "Success!",
+      kind: "info",
+    });
+  } catch {
+    // Best effort success notification; export already completed.
+  }
 }
 
 function formatDate(iso: string): string {

--- a/src/app/list/list-controller.test.ts
+++ b/src/app/list/list-controller.test.ts
@@ -9,6 +9,16 @@ import {
   fireRecordingsChanged,
 } from "./index";
 
+const { saveDialogMock, messageDialogMock } = vi.hoisted(() => ({
+  saveDialogMock: vi.fn(),
+  messageDialogMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  save: saveDialogMock,
+  message: messageDialogMock,
+}));
+
 function makeContainer(): HTMLElement {
   const el = document.createElement("div");
   document.body.appendChild(el);
@@ -24,6 +34,8 @@ describe("ListController", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    saveDialogMock.mockReset();
+    messageDialogMock.mockReset();
     container.remove();
   });
 
@@ -159,6 +171,121 @@ describe("ListController", () => {
 
     expect(confirmSpy).toHaveBeenCalledWith("Delete this recording?");
     expect(container.querySelector(".empty-state")).not.toBeNull();
+  });
+
+  it("shows export action when store supports export", async () => {
+    const store = new NoopRecordingStore();
+    store.canExportRecordings = () => true;
+
+    const { RecordingService } = await import("../recording-service");
+    const service = new RecordingService(store);
+    await saveInNewRecording(service, "A note");
+
+    const ctrl = new ListController({ container, store });
+    await ctrl.refresh();
+
+    const selector = container.querySelector<HTMLButtonElement>(
+      ".recording-item-selector",
+    );
+    selector?.click();
+
+    const labels = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        ".recording-item-menu-item",
+      ),
+    ).map((button) => button.textContent);
+    expect(labels).toEqual(["Export", "Delete"]);
+  });
+
+  it("exports recording with save dialog path", async () => {
+    const store = new NoopRecordingStore();
+    store.canExportRecordings = () => true;
+
+    const exportSpy = vi.fn(async () => undefined);
+    store.exportRecording = exportSpy;
+    saveDialogMock.mockResolvedValue("/tmp/session-export");
+
+    const { RecordingService } = await import("../recording-service");
+    const service = new RecordingService(store);
+    await saveInNewRecording(service, "A note");
+
+    const ctrl = new ListController({ container, store });
+    await ctrl.refresh();
+
+    const recordingId =
+      container.querySelector<HTMLElement>(".recording-item")?.dataset
+        .recordingId;
+    expect(recordingId).toBeTruthy();
+    const recording = (await store.listRecordings())[0];
+    expect(recording).toBeTruthy();
+
+    const selector = container.querySelector<HTMLButtonElement>(
+      ".recording-item-selector",
+    );
+    selector?.click();
+
+    const exportButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        ".recording-item-menu-item",
+      ),
+    ).find((button) => button.textContent === "Export");
+    exportButton?.click();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(saveDialogMock).toHaveBeenCalledWith({
+      title: "Export Recording Session",
+      defaultPath: `${toDateFilename(recording!.createdAt)}.zip`,
+      filters: [{ name: "Zip Archive", extensions: ["zip"] }],
+    });
+    expect(exportSpy).toHaveBeenCalledWith(
+      recordingId,
+      "/tmp/session-export.zip",
+    );
+  });
+
+  it("shows success notification after export", async () => {
+    const store = new NoopRecordingStore();
+    store.canExportRecordings = () => true;
+
+    const exportSpy = vi.fn(async () => undefined);
+    store.exportRecording = exportSpy;
+    saveDialogMock.mockResolvedValue("/tmp/session-export");
+
+    const { RecordingService } = await import("../recording-service");
+    const service = new RecordingService(store);
+    await saveInNewRecording(service, "A note");
+
+    const ctrl = new ListController({ container, store });
+    await ctrl.refresh();
+
+    const recordingId =
+      container.querySelector<HTMLElement>(".recording-item")?.dataset
+        .recordingId;
+    expect(recordingId).toBeTruthy();
+
+    const selector = container.querySelector<HTMLButtonElement>(
+      ".recording-item-selector",
+    );
+    selector?.click();
+
+    const exportButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        ".recording-item-menu-item",
+      ),
+    ).find((button) => button.textContent === "Export");
+    exportButton?.click();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(exportSpy).toHaveBeenCalled();
+    expect(messageDialogMock).toHaveBeenCalledWith(
+      "Exported to /tmp/session-export.zip",
+      {
+        title: "Success!",
+        kind: "info",
+      },
+    );
   });
 
   it("keeps recording when delete confirmation is canceled", async () => {
@@ -297,6 +424,16 @@ describe("ListController", () => {
 
 function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function toDateFilename(iso: string): string {
+  const date = new Date(iso);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${d}_${hh}-${mm}`;
 }
 
 function deferred<T>(): {

--- a/src/storage/noop-store.ts
+++ b/src/storage/noop-store.ts
@@ -56,6 +56,19 @@ export class NoopRecordingStore implements RecordingStore {
     }
   }
 
+  canExportRecordings(): boolean {
+    return false;
+  }
+
+  async exportRecording(
+    _recordingId: string,
+    _destinationPath: string,
+  ): Promise<void> {
+    void _recordingId;
+    void _destinationPath;
+    throw new Error("Recording export is only available in the desktop app.");
+  }
+
   async readText(path: string): Promise<string> {
     const text = this.textByPath.get(path);
     if (text === undefined) {

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -25,6 +25,8 @@ export interface RecordingStore {
   getRecording(recordingId: string): Promise<Recording | null>;
   saveRecording(recording: Recording): Promise<void>;
   deleteRecording(recordingId: string): Promise<void>;
+  canExportRecordings(): boolean;
+  exportRecording(recordingId: string, destinationPath: string): Promise<void>;
   readText(path: string): Promise<string>;
   writeAttachmentText(
     input: WriteAttachmentTextInput,

--- a/src/storage/tauri-store.ts
+++ b/src/storage/tauri-store.ts
@@ -33,6 +33,17 @@ export class TauriRecordingStore implements RecordingStore {
     return invoke<void>("storage_delete_recording", { recordingId });
   }
 
+  canExportRecordings(): boolean {
+    return true;
+  }
+
+  exportRecording(recordingId: string, destinationPath: string): Promise<void> {
+    return invoke<void>("storage_export_recording", {
+      recordingId,
+      destinationPath,
+    });
+  }
+
   readText(path: string): Promise<string> {
     return invoke<string>("storage_read_text", { path });
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1073,7 +1073,7 @@ body {
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--error);
+  color: var(--text-primary);
   text-align: left;
   padding: var(--space-2) var(--space-3);
   font-size: 14px;
@@ -1082,6 +1082,15 @@ body {
 
 .recording-item-menu-item:active {
   background: var(--bg-secondary);
+}
+
+.recording-item-menu-item:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.recording-item-menu-item-destructive {
+  color: var(--error);
 }
 
 .recording-date {


### PR DESCRIPTION
Summary
- upgrade the Rust storage export flow to zip 8.x, add zip64-safe directory traversal, and expose the new Tauri command
- extend the store/store UI to surface an Export action that prompts for a filename based on the recording date
- show a native success notification after export and keep the menu/destructive styles aligned with the new behavior

Testing
- Not run (not requested)