### PR TITLE
Rebrand settings view around capabilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,119 +301,138 @@
           <h2 class="view-title">Settings</h2>
         </header>
         <div class="view-body">
+          <h3>App</h3>
           <p id="pluginSummary" class="placeholder">
-            Plugin registry loading...
+            Loading app capabilities...
           </p>
-          <h3>ASR Runtime</h3>
+          <h3>Dictation</h3>
           <div class="settings-grid">
             <label class="setting-toggle">
               <input id="asrEnabled" type="checkbox" />
-              <span>Enable ASR</span>
+              <span>Enable dictation</span>
             </label>
             <label class="setting-toggle">
               <input id="asrBeamSearchEnabled" type="checkbox" />
-              <span>Enable Beam Search (KenLM)</span>
+              <span>Enhanced dictation</span>
             </label>
           </div>
-          <h3>ASR Quality</h3>
-          <div class="settings-grid">
-            <label class="setting-field">
-              <span>Silence RMS</span>
-              <input
-                id="asrSilenceRms"
-                type="number"
-                min="0.0001"
-                max="0.05"
-                step="0.0001"
-              />
-            </label>
-            <label class="setting-field">
-              <span>Silence Peak</span>
-              <input
-                id="asrSilencePeak"
-                type="number"
-                min="0.0001"
-                max="0.2"
-                step="0.0001"
-              />
-            </label>
-            <label class="setting-field">
-              <span>Silence Hangover (ms)</span>
-              <input
-                id="asrSilenceHangoverMs"
-                type="range"
-                min="100"
-                max="2000"
-                step="50"
-              />
-              <output id="asrSilenceHangoverOutput">500</output>
-            </label>
-            <label class="setting-field">
-              <span>ORT Threads</span>
-              <input
-                id="asrOrtThreads"
-                type="number"
-                min="1"
-                max="2"
-                step="1"
-              />
-            </label>
-            <label class="setting-field">
-              <span>Beam Width</span>
-              <input
-                id="asrBeamWidth"
-                type="number"
-                min="1"
-                max="32"
-                step="1"
-              />
-            </label>
-            <label class="setting-field">
-              <span>LM Alpha</span>
-              <input id="asrLmAlpha" type="number" min="0" max="3" step="0.1" />
-            </label>
-            <label class="setting-field">
-              <span>LM Beta</span>
-              <input id="asrLmBeta" type="number" min="-2" max="5" step="0.1" />
-            </label>
-            <label class="setting-field">
-              <span>Min Token LogP</span>
-              <input
-                id="asrMinTokenLogp"
-                type="number"
-                min="-20"
-                max="0"
-                step="0.1"
-              />
-            </label>
-            <label class="setting-field">
-              <span>Beam Prune LogP</span>
-              <input
-                id="asrBeamPruneLogp"
-                type="number"
-                min="-30"
-                max="0"
-                step="0.1"
-              />
-            </label>
-          </div>
+          <p class="status">
+            Experimental: Enhanced dictation may be slower on some devices.
+          </p>
+          <details class="settings-advanced">
+            <summary>Advanced dictation tuning</summary>
+            <div class="settings-grid">
+              <label class="setting-field">
+                <span>Silence RMS</span>
+                <input
+                  id="asrSilenceRms"
+                  type="number"
+                  min="0.0001"
+                  max="0.05"
+                  step="0.0001"
+                />
+              </label>
+              <label class="setting-field">
+                <span>Silence Peak</span>
+                <input
+                  id="asrSilencePeak"
+                  type="number"
+                  min="0.0001"
+                  max="0.2"
+                  step="0.0001"
+                />
+              </label>
+              <label class="setting-field">
+                <span>Silence Hangover (ms)</span>
+                <input
+                  id="asrSilenceHangoverMs"
+                  type="range"
+                  min="100"
+                  max="2000"
+                  step="50"
+                />
+                <output id="asrSilenceHangoverOutput">500</output>
+              </label>
+              <label class="setting-field">
+                <span>ORT Threads</span>
+                <input
+                  id="asrOrtThreads"
+                  type="number"
+                  min="1"
+                  max="2"
+                  step="1"
+                />
+              </label>
+              <label class="setting-field">
+                <span>Beam Width</span>
+                <input
+                  id="asrBeamWidth"
+                  type="number"
+                  min="1"
+                  max="32"
+                  step="1"
+                />
+              </label>
+              <label class="setting-field">
+                <span>LM Alpha</span>
+                <input
+                  id="asrLmAlpha"
+                  type="number"
+                  min="0"
+                  max="3"
+                  step="0.1"
+                />
+              </label>
+              <label class="setting-field">
+                <span>LM Beta</span>
+                <input
+                  id="asrLmBeta"
+                  type="number"
+                  min="-2"
+                  max="5"
+                  step="0.1"
+                />
+              </label>
+              <label class="setting-field">
+                <span>Min Token LogP</span>
+                <input
+                  id="asrMinTokenLogp"
+                  type="number"
+                  min="-20"
+                  max="0"
+                  step="0.1"
+                />
+              </label>
+              <label class="setting-field">
+                <span>Beam Prune LogP</span>
+                <input
+                  id="asrBeamPruneLogp"
+                  type="number"
+                  min="-30"
+                  max="0"
+                  step="0.1"
+                />
+              </label>
+            </div>
+          </details>
           <div class="actions">
             <button id="saveAsrSettingsBtn" type="button">
-              Save ASR Settings
+              Save Dictation Settings
             </button>
           </div>
           <p id="asrSettingsStatus" class="status"></p>
-          <h3>Models</h3>
+          <h3>AI Tools</h3>
           <div id="pluginList" class="plugin-list"></div>
           <div class="actions">
-            <button id="importPluginBtn" type="button">
-              Import Model File
-            </button>
             <button id="toggleLlmBtn" type="button" disabled>
-              Start LLM Service
+              Start AI Tools Service
             </button>
           </div>
-          <p id="llmServiceStatus" class="status">LLM service: unavailable</p>
+          <h3>Imports</h3>
+          <div class="actions">
+            <button id="importPluginBtn" type="button">Import Tool File</button>
+          </div>
+          <p id="llmServiceStatus" class="status">AI tools: unavailable</p>
         </div>
       </section>
     </main>

--- a/src/app/asr-settings-controller.ts
+++ b/src/app/asr-settings-controller.ts
@@ -81,12 +81,13 @@ export class AsrSettingsController {
     );
     this.updateFieldState();
     this.statusEl.textContent =
-      "Tune ASR values here. Saving reloads the app and applies new settings.";
+      "Tune dictation behavior here. Saving reloads the app and applies updates.";
   }
 
   private save(): void {
     if (this.isRecording()) {
-      this.statusEl.textContent = "Stop recording before saving ASR settings.";
+      this.statusEl.textContent =
+        "Stop recording before saving dictation settings.";
       return;
     }
 
@@ -112,12 +113,12 @@ export class AsrSettingsController {
       writeAsrSettings(next);
       this.populate(next);
       this.statusEl.textContent =
-        "ASR settings saved. Reloading to apply updated runtime settings...";
+        "Dictation settings saved. Reloading to apply updates...";
       window.setTimeout(() => {
         window.location.reload();
       }, 150);
     } catch (error) {
-      this.onError(error, "Failed to save ASR settings");
+      this.onError(error, "Failed to save dictation settings");
     }
   }
 

--- a/src/app/llm-controller.ts
+++ b/src/app/llm-controller.ts
@@ -49,7 +49,7 @@ export class LlmController {
     this.state = await this.platform.status();
     this.onStateChange(this.state);
     if (startError) {
-      this.onStatus(`LLM service error: ${startError}`);
+      this.onStatus(`AI tools error: ${startError}`);
     }
     return this.state;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,7 +178,7 @@ window.addEventListener("DOMContentLoaded", () => {
   });
   toggleLlmBtn.addEventListener("click", () => {
     void toggleLlmService().catch((error) =>
-      reportUnexpectedError(error, "LLM service toggle failed"),
+      reportUnexpectedError(error, "AI tools toggle failed"),
     );
   });
   window.addEventListener("error", (event) => {
@@ -397,13 +397,15 @@ function updateLlmControls(): void {
   const running = pluginState?.llmRunning ?? false;
   importPluginBtn.disabled = !canImport;
   toggleLlmBtn.disabled = !hasProvider;
-  toggleLlmBtn.textContent = running ? "Stop LLM Service" : "Start LLM Service";
+  toggleLlmBtn.textContent = running
+    ? "Stop AI Tools Service"
+    : "Start AI Tools Service";
 }
 
 function renderPluginStatus(): void {
   if (!pluginState) {
-    pluginSummaryEl.textContent = "Plugin registry loading...";
-    llmStatusEl.textContent = "LLM service: unavailable";
+    pluginSummaryEl.textContent = "Loading app capabilities...";
+    llmStatusEl.textContent = "AI tools: unavailable";
     recordingView.setTranscribeAvailable(false);
     updateAsrLoadingIndicator();
     updateLlmControls();
@@ -414,7 +416,7 @@ function renderPluginStatus(): void {
   const summary = formatPluginSummary(pluginState);
   pluginSummaryEl.textContent = asrSettings.asrEnabled
     ? summary
-    : `${summary} | ASR disabled in settings`;
+    : `${summary} | Dictation disabled in settings`;
   llmStatusEl.textContent = formatLlmStatus(pluginState);
   recordingView.setTranscribeAvailable(isAsrTranscriptionEnabled());
   updateAsrLoadingIndicator();
@@ -430,6 +432,10 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
+function formatPluginType(kind: string): string {
+  return `type: ${kind.toUpperCase()}`;
+}
+
 function renderPluginList(): void {
   // Scoped to LLM for now
   const plugins = pluginState?.plugins.filter((p) => p.kind === "llm") ?? [];
@@ -437,7 +443,7 @@ function renderPluginList(): void {
 
   if (plugins.length === 0) {
     pluginListEl.innerHTML =
-      '<p class="plugin-list-empty">No models imported yet.</p>';
+      '<p class="plugin-list-empty">No AI tools imported yet.</p>';
     return;
   }
 
@@ -456,7 +462,7 @@ function renderPluginList(): void {
 
     const meta = document.createElement("div");
     meta.className = "plugin-meta";
-    const parts: string[] = [plugin.kind.toUpperCase()];
+    const parts: string[] = [formatPluginType(plugin.kind)];
     if (plugin.pluginId === activeId) parts.push("active");
     if (plugin.sizeBytes) parts.push(formatFileSize(plugin.sizeBytes));
     meta.textContent = parts.join(" / ");
@@ -480,7 +486,7 @@ function renderPluginList(): void {
 async function deletePlugin(pluginId: string, name: string): Promise<void> {
   const confirmFn = window.confirm as unknown as (message?: string) => unknown;
   const confirmed = await confirmFn(
-    `Delete "${name}"? This removes the model file permanently.`,
+    `Delete "${name}"? This removes the tool file permanently.`,
   );
   if (!confirmed) {
     return;
@@ -496,7 +502,7 @@ async function deletePlugin(pluginId: string, name: string): Promise<void> {
 
 async function importPlugin(): Promise<void> {
   if (!pluginState?.canImport) {
-    llmStatusEl.textContent = "Import unavailable outside desktop runtime";
+    llmStatusEl.textContent = "Imports are only available in the desktop app";
     return;
   }
 
@@ -508,11 +514,11 @@ async function importPlugin(): Promise<void> {
     }
 
     const displayName = window.prompt(
-      "Optional display name for this model (leave blank to use filename):",
+      "Optional display name for this tool (leave blank to use filename):",
       "",
     );
 
-    llmStatusEl.textContent = "Importing model\u2026 0%";
+    llmStatusEl.textContent = "Importing tool\u2026 0%";
     const { listen } = await import("@tauri-apps/api/event");
     const unlisten = await listen<{
       copiedBytes: number;
@@ -521,7 +527,7 @@ async function importPlugin(): Promise<void> {
       const { copiedBytes, totalBytes } = event.payload;
       if (totalBytes > 0) {
         const pct = Math.round((copiedBytes / totalBytes) * 100);
-        llmStatusEl.textContent = `Importing model\u2026 ${pct}%`;
+        llmStatusEl.textContent = `Importing tool\u2026 ${pct}%`;
       }
     });
     let imported;
@@ -533,7 +539,7 @@ async function importPlugin(): Promise<void> {
     } finally {
       unlisten();
     }
-    llmStatusEl.textContent = `Imported plugin: ${imported.name}`;
+    llmStatusEl.textContent = `Imported tool: ${imported.name}`;
     await initializePlugins();
     if (
       imported.kind === "asr" &&

--- a/src/plugins/platform.ts
+++ b/src/plugins/platform.ts
@@ -40,34 +40,34 @@ function toErrorMessage(error: unknown): string {
 
 export function formatPluginSummary(state: PluginPlatformState): string {
   if (state.error) {
-    return `Plugin platform error: ${state.error}`;
+    return `App capabilities unavailable: ${state.error}`;
   }
 
   const lines: string[] = [];
   if (state.activeAsr) {
-    lines.push(`ASR: ${state.activeAsr.name}`);
+    lines.push(`Dictation: ${state.activeAsr.name}`);
   } else {
-    lines.push("ASR: none configured");
+    lines.push("Dictation: unavailable");
   }
 
   if (state.activeLlm) {
-    lines.push(`LLM: ${state.activeLlm.name}`);
+    lines.push(`AI tools: ${state.activeLlm.name}`);
   } else if (state.llmCount > 0) {
-    lines.push(`LLM: ${state.llmCount} installed, none active`);
+    lines.push(`AI tools: ${state.llmCount} installed, none active`);
   } else {
-    lines.push("LLM: unavailable (core dictation only)");
+    lines.push("AI tools: unavailable");
   }
   return lines.join(" | ");
 }
 
 export function formatLlmStatus(state: PluginPlatformState): string {
   if (!state.activeLlm) {
-    return "LLM service: unavailable";
+    return "AI tools: unavailable";
   }
   if (state.llmEndpoint) {
-    return `LLM service: ${state.llmStatus} (${state.llmEndpoint})`;
+    return `AI tools: ${state.llmStatus} (${state.llmEndpoint})`;
   }
-  return `LLM service: ${state.llmStatus}`;
+  return `AI tools: ${state.llmStatus}`;
 }
 
 async function resolveAppDataDir(): Promise<string> {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1143,6 +1143,25 @@ body {
   margin-bottom: var(--space-4);
 }
 
+#screen-settings .settings-advanced {
+  margin-bottom: var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+#screen-settings .settings-advanced > summary {
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+#screen-settings .settings-advanced .settings-grid {
+  margin-top: var(--space-3);
+}
+
 #screen-settings .actions {
   display: flex;
   gap: var(--space-2);


### PR DESCRIPTION
Summary:
- Rename settings sections to App, Dictation, AI Tools, and move Imports to the bottom with type exposure preserved.
- Rebrand beam search UI copy to “Enhanced dictation,” add an experimental warning, and hide advanced tuning inside an expandable panel while keeping knobs intact.
- Update status text and controller messaging to reflect the new terminology around dictation and AI tools, and display plugin type in the list.

Testing:
- Not run (not requested)