### PR TITLE
Improve plugin import cleanup and update limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,6 +525,12 @@
           <div id="pluginList" class="plugin-list"></div>
           <div class="actions">
             <button id="importPluginBtn" type="button">Import Plugin</button>
+            <div id="importProgress" class="import-progress" hidden>
+              <span class="dot"></span>
+              <span class="dot"></span>
+              <span class="dot"></span>
+              <span class="import-progress-label"></span>
+            </div>
           </div>
         </div>
       </section>

--- a/src-tauri/src/plugins/import.rs
+++ b/src-tauri/src/plugins/import.rs
@@ -1,26 +1,117 @@
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
+use zip::ZipArchive;
 
-use super::{err_to_string, PluginImportRequest, PluginKind, PluginManifest};
+use super::{
+    err_to_string,
+    manifest_utils::{is_supported_runtime, is_valid_semver},
+    PluginImportRequest, PluginKind, PluginManifest,
+};
 
-const ASR_ORT_PACKAGE_SCHEMA: &str = "dr-toru.asr.ort-package.v1";
+const PACKAGE_SCHEMA_V1: &str = "dr-toru.package.v1";
+const PACKAGE_MANIFEST_FILE: &str = "dr_toru_package.json";
+const MAX_ZIP_ENTRY_BYTES: u64 = 5_u64 * 1024 * 1024 * 1024;
+const MAX_ZIP_TOTAL_BYTES: u64 = 12_u64 * 1024 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct AsrOrtImportPackage {
-    schema: Option<String>,
+struct ZipImportManifest {
+    schema: String,
+    kind: PluginKind,
+    runtime: String,
     name: Option<String>,
-    model_path: String,
-    vocab_path: String,
-    lm_path: Option<String>,
-    kenlm_wasm_path: Option<String>,
+    version: Option<String>,
+    model_family: Option<String>,
+    license: Option<String>,
+    entrypoint: String,
+    #[serde(default)]
+    assets: Map<String, Value>,
+    runtime_config: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct InstallAsset {
+    source_path: PathBuf,
+    relative_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+struct AssetBinding {
+    key: String,
+    asset: InstallAsset,
+}
+
+#[derive(Debug)]
+struct ParsedZipPackage {
+    kind: PluginKind,
+    runtime: String,
+    name: String,
+    version: String,
+    model_family: Option<String>,
+    license: Option<String>,
+    entrypoint: InstallAsset,
+    assets: Vec<AssetBinding>,
+    supplemental_assets: Vec<InstallAsset>,
+    runtime_config: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct CopiedAsset {
+    relative_path: String,
+    hash: String,
+    size_bytes: u64,
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+struct CleanupDirGuard {
+    path: PathBuf,
+    committed: bool,
+}
+
+impl CleanupDirGuard {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            committed: false,
+        }
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for CleanupDirGuard {
+    fn drop(&mut self) {
+        if !self.committed && self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
 }
 
 fn sanitize_slug(value: &str) -> String {
@@ -54,21 +145,87 @@ fn now_suffix() -> String {
     millis.to_string()
 }
 
-/// Copy a file while computing its SHA256 in a single pass.
+fn normalize_relative_path(path: &Path) -> Result<PathBuf, String> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => continue,
+            Component::Normal(part) => normalized.push(part),
+            _ => {
+                return Err(format!(
+                    "Path must be relative and cannot escape package: {}",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return Err("Path cannot be empty".to_string());
+    }
+
+    Ok(normalized)
+}
+
+fn normalize_relative_path_str(value: &str) -> Result<PathBuf, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("Path cannot be empty".to_string());
+    }
+    normalize_relative_path(Path::new(trimmed))
+}
+
+fn relative_path_to_string(path: &Path) -> Result<String, String> {
+    let normalized = normalize_relative_path(path)?;
+    let mut parts = Vec::new();
+    for component in normalized.components() {
+        match component {
+            Component::Normal(part) => {
+                let text = part.to_str().ok_or_else(|| {
+                    format!("Path contains non-UTF8 segment: {}", normalized.display())
+                })?;
+                parts.push(text.to_string());
+            }
+            _ => {
+                return Err(format!(
+                    "Path contains invalid component: {}",
+                    normalized.display()
+                ));
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        return Err("Path cannot be empty".to_string());
+    }
+
+    Ok(parts.join("/"))
+}
+
+fn asset_hash_field_name(key: &str) -> String {
+    if let Some(prefix) = key.strip_suffix("Path") {
+        return format!("{prefix}Hash");
+    }
+    format!("{key}Hash")
+}
+
+/// Copy a file while computing its hash in a single pass.
 /// Emits "plugin-import-progress" events so the frontend can show progress.
 fn copy_imported_asset(
     app: &AppHandle,
     plugin_id: &str,
     source: &Path,
+    relative_asset_path: &Path,
 ) -> Result<(String, String, u64), String> {
-    let file_name = source
-        .file_name()
-        .and_then(|value| value.to_str())
-        .ok_or_else(|| format!("Invalid source file name: {}", source.display()))?;
+    let relative_asset = normalize_relative_path(relative_asset_path)?;
+    let relative_asset_text = relative_path_to_string(&relative_asset)?;
 
-    let relative_path = format!("plugins/assets/{plugin_id}/{file_name}");
     let app_data_dir = app.path().app_data_dir().map_err(err_to_string)?;
-    let destination = app_data_dir.join(&relative_path);
+    let destination = app_data_dir
+        .join("plugins")
+        .join("assets")
+        .join(plugin_id)
+        .join(&relative_asset);
     let Some(parent) = destination.parent() else {
         return Err("Invalid destination path".to_string());
     };
@@ -91,22 +248,24 @@ fn copy_imported_asset(
         hasher.update(&buffer[..n]);
         copied += n as u64;
 
-        // Throttle events to ~4/sec
+        // Throttle events to around 4/sec.
         if last_emit.elapsed().as_millis() >= 250 {
             last_emit = Instant::now();
             let _ = app.emit(
                 "plugin-import-progress",
                 serde_json::json!({
-                    "fileName": file_name,
+                    "fileName": relative_asset_text,
                     "copiedBytes": copied,
                     "totalBytes": total_bytes,
                 }),
             );
         }
     }
+
     dst_file.flush().map_err(err_to_string)?;
 
     let hash = hasher.finalize().to_hex().to_string();
+    let relative_path = format!("plugins/assets/{plugin_id}/{relative_asset_text}");
     Ok((relative_path, hash, copied))
 }
 
@@ -116,7 +275,8 @@ fn mark_executable(app: &AppHandle, relative_path: &str) -> Result<(), String> {
     let path = app_data_dir.join(relative_path);
     let meta = fs::metadata(&path).map_err(err_to_string)?;
     let mut perms = meta.permissions();
-    perms.set_mode(perms.mode() | 0o755);
+    // Imported binaries only need the owner execute bit added.
+    perms.set_mode(perms.mode() | 0o100);
     fs::set_permissions(&path, perms).map_err(err_to_string)
 }
 
@@ -125,151 +285,316 @@ fn mark_executable(_app: &AppHandle, _relative_path: &str) -> Result<(), String>
     Ok(())
 }
 
-fn onnx_vocab_candidate_names(stem: &str) -> Vec<String> {
-    vec![
-        format!("{stem}_vocab.json"),
-        format!("{stem}.vocab.json"),
-        "vocab.json".to_string(),
-    ]
-}
+fn copy_stream_with_limit(
+    input: &mut impl Read,
+    output: &mut impl Write,
+    max_bytes: u64,
+    context: &str,
+) -> Result<u64, String> {
+    let mut buffer = [0_u8; 256 * 1024];
+    let mut copied: u64 = 0;
 
-fn find_onnx_vocab_path(source: &Path) -> Option<PathBuf> {
-    let stem = source.file_stem().and_then(|value| value.to_str())?;
-    let parent = source.parent()?;
-    onnx_vocab_candidate_names(stem)
-        .into_iter()
-        .map(|name| parent.join(name))
-        .find(|candidate| candidate.exists() && candidate.is_file())
-}
+    loop {
+        let n = input.read(&mut buffer).map_err(err_to_string)?;
+        if n == 0 {
+            break;
+        }
 
-fn onnx_lm_candidate_names(stem: &str) -> Vec<String> {
-    vec![
-        "lm_6.kenlm".to_string(),
-        format!("{stem}.kenlm"),
-        format!("{stem}_lm.kenlm"),
-    ]
-}
-
-fn find_onnx_lm_path(source: &Path) -> Option<PathBuf> {
-    let stem = source.file_stem().and_then(|value| value.to_str())?;
-    let parent = source.parent()?;
-    onnx_lm_candidate_names(stem)
-        .into_iter()
-        .map(|name| parent.join(name))
-        .find(|candidate| candidate.exists() && candidate.is_file())
-}
-
-fn find_onnx_kenlm_js_path(source: &Path) -> Option<PathBuf> {
-    let parent = source.parent()?;
-    let candidate = parent.join("kenlm.js");
-    if candidate.exists() && candidate.is_file() {
-        return Some(candidate);
-    }
-    None
-}
-
-fn resolve_package_asset_path(package_file: &Path, value: &str) -> Result<PathBuf, String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err("Package asset path cannot be empty".to_string());
-    }
-
-    let candidate = PathBuf::from(trimmed);
-    let resolved = if candidate.is_absolute() {
-        candidate
-    } else {
-        let Some(base_dir) = package_file.parent() else {
-            return Err("Package file has no parent directory".to_string());
-        };
-        base_dir.join(candidate)
-    };
-
-    if !resolved.exists() || !resolved.is_file() {
-        return Err(format!("Package asset not found: {}", resolved.display()));
-    }
-    Ok(resolved)
-}
-
-fn load_asr_ort_package(
-    source: &Path,
-) -> Result<
-    (
-        Option<String>,
-        PathBuf,
-        PathBuf,
-        Option<PathBuf>,
-        Option<PathBuf>,
-    ),
-    String,
-> {
-    let raw = fs::read_to_string(source).map_err(err_to_string)?;
-    let package: AsrOrtImportPackage = serde_json::from_str(&raw).map_err(err_to_string)?;
-
-    if let Some(schema) = package.schema.as_ref() {
-        if schema != ASR_ORT_PACKAGE_SCHEMA {
+        copied = copied
+            .checked_add(n as u64)
+            .ok_or_else(|| format!("{context} exceeds maximum size"))?;
+        if copied > max_bytes {
             return Err(format!(
-                "Unsupported ASR package schema: {schema} (expected {ASR_ORT_PACKAGE_SCHEMA})"
+                "{context} exceeds maximum size of {max_bytes} bytes"
             ));
         }
+
+        output.write_all(&buffer[..n]).map_err(err_to_string)?;
     }
 
-    let model_path = resolve_package_asset_path(source, &package.model_path)?;
-    let model_ext = model_path
-        .extension()
-        .and_then(|value| value.to_str())
-        .map(|value| value.to_ascii_lowercase())
-        .ok_or_else(|| "Package modelPath must reference a .onnx file".to_string())?;
-    if model_ext != "onnx" {
-        return Err("Package modelPath must reference a .onnx file".to_string());
+    Ok(copied)
+}
+
+fn extract_zip_to_temp(source: &Path) -> Result<PathBuf, String> {
+    extract_zip_to_temp_with_limits(source, MAX_ZIP_ENTRY_BYTES, MAX_ZIP_TOTAL_BYTES)
+}
+
+fn extract_zip_to_temp_with_limits(
+    source: &Path,
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+) -> Result<PathBuf, String> {
+    let extract_root = std::env::temp_dir().join(format!("dr-toru-plugin-import-{}", now_suffix()));
+    fs::create_dir_all(&extract_root).map_err(err_to_string)?;
+
+    let result = (|| {
+        let file = File::open(source).map_err(err_to_string)?;
+        let mut archive = ZipArchive::new(file).map_err(err_to_string)?;
+        if archive.len() == 0 {
+            return Err("Zip package is empty".to_string());
+        }
+        let mut total_copied: u64 = 0;
+
+        for index in 0..archive.len() {
+            let mut entry = archive.by_index(index).map_err(err_to_string)?;
+            let entry_name = entry.name().to_string();
+            if entry.size() > max_entry_bytes {
+                return Err(format!(
+                    "Zip entry {entry_name} exceeds maximum size of {max_entry_bytes} bytes"
+                ));
+            }
+            let projected_size = total_copied
+                .checked_add(entry.size())
+                .ok_or_else(|| "Zip package exceeds maximum total size".to_string())?;
+            if projected_size > max_total_bytes {
+                return Err(format!(
+                    "Zip package exceeds maximum total size of {max_total_bytes} bytes"
+                ));
+            }
+
+            if let Some(mode) = entry.unix_mode() {
+                if mode & 0o170000 == 0o120000 {
+                    return Err(format!("Zip package cannot contain symlinks: {entry_name}"));
+                }
+            }
+
+            let Some(enclosed) = entry.enclosed_name().map(|value| value.to_path_buf()) else {
+                return Err(format!("Zip entry has invalid path: {entry_name}"));
+            };
+            let normalized = normalize_relative_path(&enclosed)?;
+            let output_path = extract_root.join(&normalized);
+
+            if entry.is_dir() {
+                fs::create_dir_all(&output_path).map_err(err_to_string)?;
+                continue;
+            }
+
+            let Some(parent) = output_path.parent() else {
+                return Err(format!("Invalid zip entry path: {entry_name}"));
+            };
+            fs::create_dir_all(parent).map_err(err_to_string)?;
+
+            let mut output_file = File::create(&output_path).map_err(err_to_string)?;
+            let copied = copy_stream_with_limit(
+                &mut entry,
+                &mut output_file,
+                max_entry_bytes,
+                &format!("Zip entry {entry_name}"),
+            )?;
+            total_copied = total_copied
+                .checked_add(copied)
+                .ok_or_else(|| "Zip package exceeds maximum total size".to_string())?;
+            if total_copied > max_total_bytes {
+                return Err(format!(
+                    "Zip package exceeds maximum total size of {max_total_bytes} bytes"
+                ));
+            }
+            output_file.flush().map_err(err_to_string)?;
+        }
+
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&extract_root);
     }
-    let vocab_path = resolve_package_asset_path(source, &package.vocab_path)?;
-    let lm_path = package
-        .lm_path
+
+    result.map(|_| extract_root)
+}
+
+fn resolve_extracted_asset_path(root: &Path, value: &str) -> Result<InstallAsset, String> {
+    let relative_path = normalize_relative_path_str(value)?;
+    let source_path = root.join(&relative_path);
+    if !source_path.exists() || !source_path.is_file() {
+        return Err(format!(
+            "Package asset not found: {}",
+            source_path.display()
+        ));
+    }
+
+    Ok(InstallAsset {
+        source_path,
+        relative_path,
+    })
+}
+
+fn insert_default_llm_metadata(fields: &mut Map<String, Value>) {
+    fields.insert(
+        "serviceStartArgs".to_string(),
+        json!(["--server", "--port", "{port}", "--nobrowser"]),
+    );
+    fields.insert(
+        "serviceHealthPath".to_string(),
+        Value::String("/health".to_string()),
+    );
+    fields.insert(
+        "serviceCompletionPath".to_string(),
+        Value::String("/completion".to_string()),
+    );
+}
+
+fn default_asr_runtime_config(runtime: &str) -> Value {
+    let asr_type = if runtime == "ort-whisper" {
+        "whisper"
+    } else {
+        "ctc"
+    };
+    json!({ "asrType": asr_type })
+}
+
+fn load_zip_package(extract_root: &Path) -> Result<ParsedZipPackage, String> {
+    let manifest_path = extract_root.join(PACKAGE_MANIFEST_FILE);
+    if !manifest_path.exists() || !manifest_path.is_file() {
+        return Err(format!(
+            "Zip package must include {} at the archive root",
+            PACKAGE_MANIFEST_FILE
+        ));
+    }
+
+    let raw = fs::read_to_string(&manifest_path).map_err(err_to_string)?;
+    let package: ZipImportManifest = serde_json::from_str(&raw).map_err(err_to_string)?;
+    let ZipImportManifest {
+        schema,
+        kind,
+        runtime,
+        name,
+        version,
+        model_family,
+        license,
+        entrypoint,
+        assets: raw_assets,
+        runtime_config,
+    } = package;
+
+    if schema != PACKAGE_SCHEMA_V1 {
+        return Err(format!(
+            "Unsupported package schema: {} (expected {})",
+            schema, PACKAGE_SCHEMA_V1
+        ));
+    }
+
+    let runtime = runtime.trim().to_string();
+    if runtime.is_empty() {
+        return Err("Package runtime is required".to_string());
+    }
+    if !is_supported_runtime(&kind, &runtime) {
+        return Err(format!(
+            "Unsupported runtime {} for kind {:?}",
+            runtime, kind
+        ));
+    }
+
+    let name = name
         .as_ref()
-        .map(|value| resolve_package_asset_path(source, value))
-        .transpose()?;
-    let kenlm_path = package
-        .kenlm_wasm_path
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Package name is required".to_string())?;
+
+    let version = version
         .as_ref()
-        .map(|value| resolve_package_asset_path(source, value))
-        .transpose()?;
-    let kenlm_js_path = match kenlm_path {
-        Some(path) => {
-            let ext = path
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Package version is required".to_string())?;
+    if !is_valid_semver(&version) {
+        return Err("Package version must follow semver x.y.z".to_string());
+    }
+
+    let entrypoint = resolve_extracted_asset_path(extract_root, &entrypoint)?;
+
+    let mut assets = Vec::new();
+    let mut seen_keys = HashSet::new();
+    let mut hash_key_to_source = HashMap::<String, String>::new();
+    for (key, value) in raw_assets {
+        let trimmed_key = key.trim().to_string();
+        if trimmed_key.is_empty() {
+            return Err("Package assets keys cannot be empty".to_string());
+        }
+        if !seen_keys.insert(trimmed_key.clone()) {
+            return Err(format!("Duplicate package asset key: {trimmed_key}"));
+        }
+
+        let hash_key = asset_hash_field_name(&trimmed_key);
+        if let Some(previous_key) = hash_key_to_source.insert(hash_key.clone(), trimmed_key.clone())
+        {
+            return Err(format!(
+                "Package assets keys {previous_key} and {trimmed_key} map to the same hash field {hash_key}"
+            ));
+        }
+
+        let Value::String(path_value) = value else {
+            return Err(format!("Package asset {} must be a string path", key));
+        };
+
+        let asset = resolve_extracted_asset_path(extract_root, &path_value)?;
+        assets.push(AssetBinding {
+            key: trimmed_key,
+            asset,
+        });
+    }
+
+    let mut supplemental_assets = Vec::new();
+    if kind == PluginKind::Asr && runtime == "ort-ctc" {
+        if !assets.iter().any(|asset| asset.key == "vocabPath") {
+            return Err("ASR runtime ort-ctc requires assets.vocabPath".to_string());
+        }
+
+        if let Some(kenlm_binding) = assets.iter_mut().find(|asset| asset.key == "kenlmWasmPath") {
+            let ext = kenlm_binding
+                .asset
+                .relative_path
                 .extension()
                 .and_then(|value| value.to_str())
                 .map(|value| value.to_ascii_lowercase())
                 .ok_or_else(|| {
-                    "Package kenlmWasmPath must reference kenlm.js or kenlm.wasm".to_string()
+                    "assets.kenlmWasmPath must reference kenlm.js or kenlm.wasm".to_string()
                 })?;
-            if ext == "js" {
-                Some(path)
-            } else if ext == "wasm" {
-                let js_path = path.with_extension("js");
-                if !js_path.exists() || !js_path.is_file() {
+
+            if ext == "wasm" {
+                let js_relative = kenlm_binding.asset.relative_path.with_extension("js");
+                let js_source = extract_root.join(&js_relative);
+                if !js_source.exists() || !js_source.is_file() {
                     return Err(format!(
-                        "Package kenlmWasmPath references {} but {} is missing",
-                        path.display(),
-                        js_path.display()
+                        "assets.kenlmWasmPath references {} but {} is missing",
+                        kenlm_binding.asset.relative_path.display(),
+                        js_relative.display()
                     ));
                 }
-                Some(js_path)
-            } else {
+                // The ASR worker expects kenlmWasmPath to point at the JS loader.
+                // If a package points this field at .wasm, normalize it here and
+                // install the .wasm as a supplemental sidecar.
+                kenlm_binding.asset = InstallAsset {
+                    source_path: js_source,
+                    relative_path: js_relative,
+                };
+            } else if ext != "js" {
                 return Err(
-                    "Package kenlmWasmPath must reference kenlm.js or kenlm.wasm".to_string(),
+                    "assets.kenlmWasmPath must reference kenlm.js or kenlm.wasm".to_string()
                 );
             }
-        }
-        None => None,
-    };
 
-    Ok((
-        package.name.filter(|value| !value.trim().is_empty()),
-        model_path,
-        vocab_path,
-        lm_path,
-        kenlm_js_path,
-    ))
+            let wasm_relative = kenlm_binding.asset.relative_path.with_extension("wasm");
+            let wasm_source = extract_root.join(&wasm_relative);
+            if wasm_source.exists() && wasm_source.is_file() {
+                supplemental_assets.push(InstallAsset {
+                    source_path: wasm_source,
+                    relative_path: wasm_relative,
+                });
+            }
+        }
+    }
+
+    Ok(ParsedZipPackage {
+        kind,
+        runtime,
+        name,
+        version,
+        model_family,
+        license,
+        entrypoint,
+        assets,
+        supplemental_assets,
+        runtime_config,
+    })
 }
 
 pub(super) fn imported_plugin_manifest(
@@ -296,50 +621,66 @@ pub(super) fn imported_plugin_manifest(
         .unwrap_or("model")
         .to_string();
 
-    let mut kind = PluginKind::Asr;
-    let mut prefix = "import.asr";
-    let mut display_name_fallback = source_stem.clone();
-    let mut entrypoint_source = source.clone();
-    let mut vocab_source: Option<PathBuf> = None;
-    let mut lm_source: Option<PathBuf> = None;
-    let mut kenlm_js_source: Option<PathBuf> = None;
-    let mut metadata = None;
+    let kind;
+    let runtime;
+    let prefix;
+    let display_name_fallback;
+    let mut version = "1.0.0".to_string();
+    let mut model_family = None;
+    let mut license = None;
+    let mut metadata_fields = Map::<String, Value>::new();
+    let entrypoint_asset;
+    let mut bound_assets: Vec<AssetBinding> = Vec::new();
+    let mut supplemental_assets: Vec<InstallAsset> = Vec::new();
+    let mut _extract_guard: Option<TempDirGuard> = None;
 
     if extension == "llamafile" {
         kind = PluginKind::Llm;
+        runtime = "llamafile".to_string();
         prefix = "import.llm";
-        metadata = Some(json!({
-            "serviceStartArgs": ["--server", "--port", "{port}", "--nobrowser"],
-            "serviceHealthPath": "/health",
-            "serviceCompletionPath": "/completion"
-        }));
-    } else if extension == "onnx" {
-        let Some(found_vocab) = find_onnx_vocab_path(&source) else {
-            let expected = onnx_vocab_candidate_names(&source_stem).join(", ");
-            return Err(format!(
-                "Missing vocab file for ONNX import. Expected one of: {expected}"
-            ));
-        };
-        vocab_source = Some(found_vocab);
-        lm_source = find_onnx_lm_path(&source);
-        kenlm_js_source = find_onnx_kenlm_js_path(&source);
-    } else if extension == "asrpkg" {
-        let (package_name, model_path, package_vocab_path, package_lm_path, package_kenlm_path) =
-            load_asr_ort_package(&source)?;
-        entrypoint_source = model_path;
-        vocab_source = Some(package_vocab_path);
-        lm_source = package_lm_path;
-        kenlm_js_source = package_kenlm_path;
-        if let Some(name) = package_name {
-            display_name_fallback = name;
-        } else if let Some(stem) = entrypoint_source
-            .file_stem()
+        display_name_fallback = source_stem.clone();
+
+        insert_default_llm_metadata(&mut metadata_fields);
+
+        let file_name = source
+            .file_name()
             .and_then(|value| value.to_str())
-        {
-            display_name_fallback = stem.to_string();
+            .ok_or_else(|| format!("Invalid source file name: {}", source.display()))?
+            .to_string();
+
+        entrypoint_asset = InstallAsset {
+            source_path: source.clone(),
+            relative_path: PathBuf::from(file_name),
+        };
+    } else if extension == "zip" {
+        let extract_root = extract_zip_to_temp(&source)?;
+        _extract_guard = Some(TempDirGuard::new(extract_root.clone()));
+
+        let package = load_zip_package(&extract_root)?;
+        kind = package.kind;
+        runtime = package.runtime;
+        prefix = if kind == PluginKind::Asr {
+            "import.asr"
+        } else {
+            "import.llm"
+        };
+        display_name_fallback = package.name;
+        version = package.version;
+        model_family = package.model_family;
+        license = package.license;
+        entrypoint_asset = package.entrypoint;
+        bound_assets = package.assets;
+        supplemental_assets = package.supplemental_assets;
+
+        if let Some(runtime_config) = package.runtime_config {
+            metadata_fields.insert("runtimeConfig".to_string(), runtime_config);
+        }
+
+        if kind == PluginKind::Llm {
+            insert_default_llm_metadata(&mut metadata_fields);
         }
     } else {
-        return Err("Only .llamafile, .onnx, and .asrpkg imports are supported".to_string());
+        return Err("Only .llamafile and .zip imports are supported".to_string());
     }
 
     let slug = sanitize_slug(&source_stem);
@@ -349,49 +690,73 @@ pub(super) fn imported_plugin_manifest(
         slug
     };
     let plugin_id = format!("{prefix}.{}.{}", slug, now_suffix());
-    let (relative_entrypoint, file_hash, entrypoint_size_bytes) =
-        copy_imported_asset(app, &plugin_id, &entrypoint_source)?;
+    let app_data_dir = app.path().app_data_dir().map_err(err_to_string)?;
+    let destination_dir = app_data_dir.join("plugins").join("assets").join(&plugin_id);
+    if destination_dir.exists() {
+        return Err(format!(
+            "Import destination already exists: {}",
+            destination_dir.display()
+        ));
+    }
+    let mut destination_guard = CleanupDirGuard::new(destination_dir);
 
+    let mut copied_assets: HashMap<String, CopiedAsset> = HashMap::new();
+    let mut total_size_bytes: u64 = 0;
+    let mut copy_asset_once = |asset: &InstallAsset| -> Result<CopiedAsset, String> {
+        let key = relative_path_to_string(&asset.relative_path)?;
+        if let Some(existing) = copied_assets.get(&key) {
+            return Ok(existing.clone());
+        }
+
+        let (relative_path, hash, size_bytes) =
+            copy_imported_asset(app, &plugin_id, &asset.source_path, &asset.relative_path)?;
+        let copied = CopiedAsset {
+            relative_path,
+            hash,
+            size_bytes,
+        };
+
+        total_size_bytes += copied.size_bytes;
+        copied_assets.insert(key, copied.clone());
+        Ok(copied)
+    };
+
+    let copied_entrypoint = copy_asset_once(&entrypoint_asset)?;
     if kind == PluginKind::Llm {
-        mark_executable(app, &relative_entrypoint)?;
+        mark_executable(app, &copied_entrypoint.relative_path)?;
     }
 
-    if kind == PluginKind::Asr {
-        let vocab = vocab_source
-            .as_ref()
-            .ok_or_else(|| "ASR import requires a vocab file".to_string())?;
-        let (relative_vocab_path, vocab_hash, _) = copy_imported_asset(app, &plugin_id, vocab)?;
-        let mut asr_metadata = json!({
-            "vocabPath": relative_vocab_path,
-            "vocabSha256": vocab_hash
-        });
-
-        if let Some(lm) = lm_source.as_ref() {
-            let (relative_lm_path, lm_hash, _) = copy_imported_asset(app, &plugin_id, lm)?;
-            if let Value::Object(fields) = &mut asr_metadata {
-                fields.insert("lmPath".to_string(), Value::String(relative_lm_path));
-                fields.insert("lmSha256".to_string(), Value::String(lm_hash));
-            }
+    if !bound_assets.is_empty() {
+        let mut assets_map = Map::new();
+        for binding in &bound_assets {
+            let copied = copy_asset_once(&binding.asset)?;
+            metadata_fields.insert(
+                binding.key.clone(),
+                Value::String(copied.relative_path.clone()),
+            );
+            metadata_fields.insert(
+                asset_hash_field_name(&binding.key),
+                Value::String(copied.hash.clone()),
+            );
+            assets_map.insert(
+                binding.key.clone(),
+                Value::String(copied.relative_path.clone()),
+            );
         }
+        metadata_fields.insert("assets".to_string(), Value::Object(assets_map));
+    }
 
-        if let Some(kenlm_js) = kenlm_js_source.as_ref() {
-            let (relative_kenlm_path, kenlm_hash, _) =
-                copy_imported_asset(app, &plugin_id, kenlm_js)?;
-            if let Value::Object(fields) = &mut asr_metadata {
-                fields.insert(
-                    "kenlmWasmPath".to_string(),
-                    Value::String(relative_kenlm_path),
-                );
-                fields.insert("kenlmWasmSha256".to_string(), Value::String(kenlm_hash));
-            }
-
-            let kenlm_wasm = kenlm_js.with_extension("wasm");
-            if kenlm_wasm.exists() && kenlm_wasm.is_file() {
-                let _ = copy_imported_asset(app, &plugin_id, &kenlm_wasm)?;
-            }
+    if !supplemental_assets.is_empty() {
+        for asset in &supplemental_assets {
+            let _ = copy_asset_once(asset)?;
         }
+    }
 
-        metadata = Some(asr_metadata);
+    if kind == PluginKind::Asr && !metadata_fields.contains_key("runtimeConfig") {
+        metadata_fields.insert(
+            "runtimeConfig".to_string(),
+            default_asr_runtime_config(&runtime),
+        );
     }
 
     let installed_at = SystemTime::now()
@@ -399,6 +764,7 @@ pub(super) fn imported_plugin_manifest(
         .unwrap_or_default()
         .as_secs()
         .to_string();
+    destination_guard.commit();
 
     Ok(PluginManifest {
         plugin_id,
@@ -407,15 +773,20 @@ pub(super) fn imported_plugin_manifest(
             .clone()
             .filter(|value| !value.trim().is_empty())
             .unwrap_or(display_name_fallback),
-        version: "1.0.0".to_string(),
+        version,
         kind,
-        entrypoint_path: relative_entrypoint,
-        sha256: file_hash,
-        model_family: None,
-        size_bytes: Some(entrypoint_size_bytes),
-        license: None,
+        runtime,
+        entrypoint_path: copied_entrypoint.relative_path,
+        hash: copied_entrypoint.hash,
+        model_family,
+        size_bytes: Some(total_size_bytes),
+        license,
         installed_at: Some(installed_at),
-        metadata,
+        metadata: if metadata_fields.is_empty() {
+            None
+        } else {
+            Some(Value::Object(metadata_fields))
+        },
     })
 }
 
@@ -435,4 +806,234 @@ pub(super) fn imported_asset_dir(
             .join("assets")
             .join(&manifest.plugin_id),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        extract_zip_to_temp, extract_zip_to_temp_with_limits, load_zip_package, now_suffix,
+        PACKAGE_MANIFEST_FILE, PACKAGE_SCHEMA_V1,
+    };
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let path =
+                std::env::temp_dir().join(format!("dr-toru-import-test-{label}-{}", now_suffix()));
+            fs::create_dir_all(&path).expect("failed to create temp dir");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            if self.0.exists() {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+    }
+
+    fn write_file(path: &Path, contents: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("failed to create parent dir");
+        }
+        let mut file = File::create(path).expect("failed to create file");
+        file.write_all(contents).expect("failed to write file");
+        file.flush().expect("failed to flush file");
+    }
+
+    #[test]
+    fn load_zip_package_accepts_valid_ctc_manifest() {
+        let dir = TempDir::new("valid");
+        write_file(dir.path().join("models/model.onnx").as_path(), b"onnx");
+        write_file(
+            dir.path().join("models/vocab.json").as_path(),
+            br#"{"tokens":[]}"#,
+        );
+        write_file(dir.path().join("kenlm/kenlm.js").as_path(), b"js");
+        write_file(dir.path().join("kenlm/kenlm.wasm").as_path(), b"wasm");
+
+        let manifest = format!(
+            r#"{{
+  "schema": "{schema}",
+  "kind": "asr",
+  "runtime": "ort-ctc",
+  "name": "Zip ASR",
+  "version": "1.2.3",
+  "entrypoint": "models/model.onnx",
+  "assets": {{
+    "vocabPath": "models/vocab.json",
+    "kenlmWasmPath": "kenlm/kenlm.js"
+  }}
+}}"#,
+            schema = PACKAGE_SCHEMA_V1
+        );
+        write_file(
+            dir.path().join(PACKAGE_MANIFEST_FILE).as_path(),
+            manifest.as_bytes(),
+        );
+
+        let parsed = load_zip_package(dir.path()).expect("expected valid package");
+        assert_eq!(parsed.runtime, "ort-ctc");
+        assert_eq!(parsed.name, "Zip ASR");
+        assert_eq!(parsed.version, "1.2.3");
+        assert_eq!(parsed.assets.len(), 2);
+        assert_eq!(parsed.supplemental_assets.len(), 1);
+    }
+
+    #[test]
+    fn load_zip_package_rejects_missing_manifest() {
+        let dir = TempDir::new("missing-manifest");
+        let error = load_zip_package(dir.path()).expect_err("expected missing manifest error");
+        assert!(error.contains(PACKAGE_MANIFEST_FILE));
+    }
+
+    #[test]
+    fn load_zip_package_rejects_missing_referenced_file() {
+        let dir = TempDir::new("missing-asset");
+        write_file(dir.path().join("models/model.onnx").as_path(), b"onnx");
+
+        let manifest = format!(
+            r#"{{
+  "schema": "{schema}",
+  "kind": "asr",
+  "runtime": "ort-ctc",
+  "name": "Zip ASR",
+  "version": "1.0.0",
+  "entrypoint": "models/model.onnx",
+  "assets": {{
+    "vocabPath": "models/missing_vocab.json"
+  }}
+}}"#,
+            schema = PACKAGE_SCHEMA_V1
+        );
+        write_file(
+            dir.path().join(PACKAGE_MANIFEST_FILE).as_path(),
+            manifest.as_bytes(),
+        );
+
+        let error = load_zip_package(dir.path()).expect_err("expected missing asset error");
+        assert!(error.contains("Package asset not found"));
+    }
+
+    #[test]
+    fn load_zip_package_rejects_invalid_runtime_for_kind() {
+        let dir = TempDir::new("invalid-runtime-kind");
+        write_file(dir.path().join("model.bin").as_path(), b"model");
+
+        let manifest = format!(
+            r#"{{
+  "schema": "{schema}",
+  "kind": "llm",
+  "runtime": "ort-ctc",
+  "name": "Zip LLM",
+  "version": "1.0.0",
+  "entrypoint": "model.bin"
+}}"#,
+            schema = PACKAGE_SCHEMA_V1
+        );
+        write_file(
+            dir.path().join(PACKAGE_MANIFEST_FILE).as_path(),
+            manifest.as_bytes(),
+        );
+
+        let error = load_zip_package(dir.path()).expect_err("expected runtime-kind error");
+        assert!(error.contains("Unsupported runtime"));
+    }
+
+    #[test]
+    fn load_zip_package_rejects_colliding_hash_keys() {
+        let dir = TempDir::new("colliding-hash-keys");
+        write_file(dir.path().join("a.bin").as_path(), b"a");
+        write_file(dir.path().join("b.bin").as_path(), b"b");
+
+        let manifest = format!(
+            r#"{{
+  "schema": "{schema}",
+  "kind": "llm",
+  "runtime": "llamafile",
+  "name": "Zip LLM",
+  "version": "1.0.0",
+  "entrypoint": "a.bin",
+  "assets": {{
+    "model": "a.bin",
+    "modelPath": "b.bin"
+  }}
+}}"#,
+            schema = PACKAGE_SCHEMA_V1
+        );
+        write_file(
+            dir.path().join(PACKAGE_MANIFEST_FILE).as_path(),
+            manifest.as_bytes(),
+        );
+
+        let error = load_zip_package(dir.path()).expect_err("expected hash key collision error");
+        assert!(error.contains("same hash field"));
+    }
+
+    #[test]
+    fn extract_zip_to_temp_rejects_entry_over_limit() {
+        let dir = TempDir::new("entry-limit");
+        let zip_path = dir.path().join("entry-limit.zip");
+
+        let mut zip = ZipWriter::new(File::create(&zip_path).expect("failed to create zip file"));
+        let options = SimpleFileOptions::default();
+        zip.start_file("large.bin", options)
+            .expect("failed to start zip entry");
+        zip.write_all(b"0123456789")
+            .expect("failed to write zip entry");
+        zip.finish().expect("failed to finish zip");
+
+        let error = extract_zip_to_temp_with_limits(&zip_path, 5, 100)
+            .expect_err("expected zip entry limit rejection");
+        assert!(error.contains("exceeds maximum size"));
+    }
+
+    #[test]
+    fn extract_zip_to_temp_rejects_total_size_over_limit() {
+        let dir = TempDir::new("total-limit");
+        let zip_path = dir.path().join("total-limit.zip");
+
+        let mut zip = ZipWriter::new(File::create(&zip_path).expect("failed to create zip file"));
+        let options = SimpleFileOptions::default();
+        zip.start_file("first.bin", options)
+            .expect("failed to start first zip entry");
+        zip.write_all(b"1234")
+            .expect("failed to write first zip entry");
+        zip.start_file("second.bin", options)
+            .expect("failed to start second zip entry");
+        zip.write_all(b"5678")
+            .expect("failed to write second zip entry");
+        zip.finish().expect("failed to finish zip");
+
+        let error = extract_zip_to_temp_with_limits(&zip_path, 100, 7)
+            .expect_err("expected total zip size rejection");
+        assert!(error.contains("maximum total size"));
+    }
+
+    #[test]
+    fn extract_zip_to_temp_rejects_path_traversal_entry() {
+        let dir = TempDir::new("path-traversal");
+        let zip_path = dir.path().join("bad.zip");
+
+        let mut zip = ZipWriter::new(File::create(&zip_path).expect("failed to create zip file"));
+        let options = SimpleFileOptions::default();
+        zip.start_file("../escape.txt", options)
+            .expect("failed to start zip entry");
+        zip.write_all(b"bad").expect("failed to write zip entry");
+        zip.finish().expect("failed to finish zip");
+
+        let error = extract_zip_to_temp(&zip_path).expect_err("expected path traversal rejection");
+        assert!(error.contains("invalid path") || error.contains("cannot escape package"));
+    }
 }

--- a/src-tauri/src/plugins/manifest_utils.rs
+++ b/src-tauri/src/plugins/manifest_utils.rs
@@ -1,0 +1,31 @@
+use super::PluginKind;
+
+pub(super) fn is_supported_runtime(kind: &PluginKind, runtime: &str) -> bool {
+    match kind {
+        PluginKind::Asr => matches!(runtime, "ort-ctc" | "ort-whisper"),
+        PluginKind::Llm => matches!(runtime, "llamafile"),
+    }
+}
+
+pub(super) fn is_valid_semver(value: &str) -> bool {
+    let (core, _) = value.split_once('-').unwrap_or((value, ""));
+    let mut parts = core.split('.');
+    let Some(major) = parts.next() else {
+        return false;
+    };
+    let Some(minor) = parts.next() else {
+        return false;
+    };
+    let Some(patch) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+    !major.is_empty()
+        && !minor.is_empty()
+        && !patch.is_empty()
+        && major.bytes().all(|byte| byte.is_ascii_digit())
+        && minor.bytes().all(|byte| byte.is_ascii_digit())
+        && patch.bytes().all(|byte| byte.is_ascii_digit())
+}

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -1,6 +1,7 @@
 pub mod asr;
 mod import;
 mod llamafile;
+mod manifest_utils;
 mod registry;
 
 use serde::{Deserialize, Serialize};
@@ -13,11 +14,11 @@ use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager, State};
 
-use import::{imported_asset_dir, imported_plugin_manifest};
 use asr::RunningAsr;
+use import::{imported_asset_dir, imported_plugin_manifest};
 use llamafile::{
-    execute_blocking, service_start_blocking, service_status_blocking,
-    stop_service, RunningLlamafile,
+    execute_blocking, service_start_blocking, service_status_blocking, stop_service,
+    RunningLlamafile,
 };
 use registry::{
     auto_activate_vacant, ensure_registry, load_registry, plugin_paths, resolve_entrypoint,
@@ -38,8 +39,10 @@ pub struct PluginManifest {
     pub name: String,
     pub version: String,
     pub kind: PluginKind,
+    pub runtime: String,
     pub entrypoint_path: String,
-    pub sha256: String,
+    #[serde(alias = "sha256")]
+    pub hash: String,
     pub model_family: Option<String>,
     pub size_bytes: Option<u64>,
     pub license: Option<String>,
@@ -98,9 +101,7 @@ impl PluginRuntimeState {
     }
 
     fn lock_running_asr(&self) -> MutexGuard<'_, HashMap<String, RunningAsr>> {
-        self.running_asr
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        self.running_asr.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     fn stop_all_running(&self) {
@@ -478,10 +479,7 @@ pub async fn plugin_runtime_llamafile_execute(
 }
 
 #[tauri::command]
-pub async fn plugin_asr_load(
-    app: AppHandle,
-    plugin_id: String,
-) -> Result<RuntimeHealth, String> {
+pub async fn plugin_asr_load(app: AppHandle, plugin_id: String) -> Result<RuntimeHealth, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let runtime_state = app.state::<PluginRuntimeState>();
 
@@ -507,6 +505,12 @@ pub async fn plugin_asr_load(
         };
         if plugin.kind != PluginKind::Asr {
             return Err(format!("Plugin {plugin_id} is not an ASR plugin"));
+        }
+        if plugin.runtime != "ort-ctc" {
+            return Err(format!(
+                "ASR runtime {} is not supported yet for {plugin_id}",
+                plugin.runtime
+            ));
         }
 
         let model_path = resolve_entrypoint(&app, &plugin.entrypoint_path)?;
@@ -562,10 +566,7 @@ pub async fn plugin_asr_transcribe(
 }
 
 #[tauri::command]
-pub fn plugin_asr_unload(
-    plugin_id: String,
-    runtime_state: State<'_, PluginRuntimeState>,
-) {
+pub fn plugin_asr_unload(plugin_id: String, runtime_state: State<'_, PluginRuntimeState>) {
     let mut running = runtime_state.lock_running_asr();
     asr::unload(&mut running, &plugin_id);
 }

--- a/src-tauri/src/plugins/registry.rs
+++ b/src-tauri/src/plugins/registry.rs
@@ -5,8 +5,10 @@ use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
 use super::{
-    err_to_string, parse_string_field, write_json_atomic, ActivePlugins, PluginKind,
-    PluginManifest, PluginRegistryState,
+    err_to_string,
+    manifest_utils::{is_supported_runtime, is_valid_semver},
+    parse_string_field, write_json_atomic, ActivePlugins, PluginKind, PluginManifest,
+    PluginRegistryState,
 };
 
 const REGISTRY_FORMAT: u8 = 1;
@@ -58,8 +60,9 @@ pub(super) fn builtin_ort_asr_plugin() -> PluginManifest {
         name: "Built-in Medical ASR".to_string(),
         version: "1.0.0".to_string(),
         kind: PluginKind::Asr,
+        runtime: "ort-ctc".to_string(),
         entrypoint_path: "models/medasr_lasr_ctc_int8.onnx".to_string(),
-        sha256: "05c1907f53d9dea3db23092e4d730f011ee400b3fb282d6af8443276dfb9d270".to_string(),
+        hash: "05c1907f53d9dea3db23092e4d730f011ee400b3fb282d6af8443276dfb9d270".to_string(),
         model_family: Some("medasr_lasr".to_string()),
         size_bytes: None,
         license: None,
@@ -70,7 +73,7 @@ pub(super) fn builtin_ort_asr_plugin() -> PluginManifest {
                 Value::String("models/medasr_lasr_vocab.json".to_string()),
             ),
             (
-                "vocabSha256".to_string(),
+                "vocabHash".to_string(),
                 Value::String(
                     "631bd152b5beca9a74d21bd1c3ff53fecf63d10d11aae72e491cacdfbf69a756".to_string(),
                 ),
@@ -82,6 +85,13 @@ pub(super) fn builtin_ort_asr_plugin() -> PluginManifest {
             (
                 "kenlmWasmPath".to_string(),
                 Value::String("kenlm/kenlm.js".to_string()),
+            ),
+            (
+                "runtimeConfig".to_string(),
+                Value::Object(Map::from_iter([(
+                    "asrType".to_string(),
+                    Value::String("ctc".to_string()),
+                )])),
             ),
         ]))),
     }
@@ -97,34 +107,11 @@ fn is_valid_plugin_id(value: &str) -> bool {
         .all(|byte| byte.is_ascii_alphanumeric() || byte == b'.' || byte == b'_' || byte == b'-')
 }
 
-fn is_valid_sha256(value: &str) -> bool {
+fn is_valid_hash(value: &str) -> bool {
     value.len() == 64
         && value
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
-}
-
-fn is_valid_semver(value: &str) -> bool {
-    let (core, _) = value.split_once('-').unwrap_or((value, ""));
-    let mut parts = core.split('.');
-    let Some(major) = parts.next() else {
-        return false;
-    };
-    let Some(minor) = parts.next() else {
-        return false;
-    };
-    let Some(patch) = parts.next() else {
-        return false;
-    };
-    if parts.next().is_some() {
-        return false;
-    }
-    !major.is_empty()
-        && !minor.is_empty()
-        && !patch.is_empty()
-        && major.bytes().all(|byte| byte.is_ascii_digit())
-        && minor.bytes().all(|byte| byte.is_ascii_digit())
-        && patch.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 pub(super) fn validate_manifest(manifest: &PluginManifest) -> Result<(), String> {
@@ -137,14 +124,23 @@ pub(super) fn validate_manifest(manifest: &PluginManifest) -> Result<(), String>
     if !is_valid_semver(&manifest.version) {
         return Err("version must follow semver x.y.z".to_string());
     }
+    if manifest.runtime.trim().is_empty() {
+        return Err("runtime is required".to_string());
+    }
+    if !is_supported_runtime(&manifest.kind, manifest.runtime.trim()) {
+        return Err(format!(
+            "runtime {} is not supported for kind {:?}",
+            manifest.runtime, manifest.kind
+        ));
+    }
     if manifest.entrypoint_path.trim().is_empty() {
         return Err("entrypointPath is required".to_string());
     }
-    if !is_valid_sha256(&manifest.sha256) {
-        return Err("sha256 must be 64 lowercase hex chars".to_string());
+    if !is_valid_hash(&manifest.hash) {
+        return Err("hash must be 64 lowercase hex chars".to_string());
     }
 
-    if manifest.kind == PluginKind::Asr {
+    if manifest.kind == PluginKind::Asr && manifest.runtime == "ort-ctc" {
         if parse_string_field(&manifest.metadata, "vocabPath")
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
@@ -201,9 +197,9 @@ fn sanitize_registry(mut state: PluginRegistryState) -> Result<PluginRegistrySta
         .llm
         .as_ref()
         .map(|plugin_id| {
-            valid_plugins.iter().any(|plugin| {
-                plugin.plugin_id == *plugin_id && plugin.kind == PluginKind::Llm
-            })
+            valid_plugins
+                .iter()
+                .any(|plugin| plugin.plugin_id == *plugin_id && plugin.kind == PluginKind::Llm)
         })
         .unwrap_or(false);
     if !has_llm_active {
@@ -217,10 +213,7 @@ fn sanitize_registry(mut state: PluginRegistryState) -> Result<PluginRegistrySta
     })
 }
 
-pub(super) fn auto_activate_vacant(
-    state: &mut PluginRegistryState,
-    manifest: &PluginManifest,
-) {
+pub(super) fn auto_activate_vacant(state: &mut PluginRegistryState, manifest: &PluginManifest) {
     match manifest.kind {
         PluginKind::Asr => {
             if state.active_plugins.asr.is_none() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,8 @@ let uploadTranscriptBtn: HTMLButtonElement;
 let transcriptUploadInput: HTMLInputElement;
 let pluginListEl: HTMLElement;
 let importPluginBtn: HTMLButtonElement;
+let importProgressEl: HTMLElement;
+let importProgressLabel: HTMLElement;
 let navBtns: HTMLButtonElement[] = [];
 let screenEls: Record<RouteName, HTMLElement>;
 let currentRoute: AppRoute | null = null;
@@ -65,6 +67,10 @@ window.addEventListener("DOMContentLoaded", () => {
   transcriptUploadInput = mustFileInput("transcriptUploadInput");
   pluginListEl = mustEl("pluginList");
   importPluginBtn = mustBtn("importPluginBtn");
+  importProgressEl = mustEl("importProgress");
+  importProgressLabel = importProgressEl.querySelector(
+    ".import-progress-label",
+  ) as HTMLElement;
 
   const asrSettingsController = new AsrSettingsController({
     isRecording: () => dictation?.isRecording ?? false,
@@ -623,10 +629,18 @@ async function importPlugin(): Promise<void> {
     );
 
     const { listen } = await import("@tauri-apps/api/event");
+    importProgressLabel.textContent = "Importing\u2026";
+    importProgressEl.hidden = false;
     const unlisten = await listen<{
       copiedBytes: number;
       totalBytes: number;
-    }>("plugin-import-progress", () => undefined);
+    }>("plugin-import-progress", (event) => {
+      const { copiedBytes, totalBytes } = event.payload;
+      if (totalBytes > 0) {
+        const pct = Math.min(100, Math.round((copiedBytes / totalBytes) * 100));
+        importProgressLabel.textContent = `${pct}%`;
+      }
+    });
     let imported;
     try {
       imported = await pluginPlatform.importFromPath({
@@ -635,6 +649,7 @@ async function importPlugin(): Promise<void> {
       });
     } finally {
       unlisten();
+      importProgressEl.hidden = true;
     }
     await refreshPluginState();
     if (

--- a/src/plugins/contracts.test.ts
+++ b/src/plugins/contracts.test.ts
@@ -31,8 +31,32 @@ describe("plugin contracts", () => {
       name: "Test LLM",
       version: "1.0.0",
       kind: "llm",
+      runtime: "llamafile",
       entrypointPath: "/tmp/model.llamafile",
-      sha256: "a".repeat(64),
+      hash: "a".repeat(64),
+    };
+
+    const issues = validatePluginManifest(manifest);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("rejects unsupported runtime for kind", () => {
+    const manifest: PluginManifest = {
+      ...BUILTIN_ORT_ASR_PLUGIN,
+      pluginId: "bad.asr.runtime",
+      runtime: "llamafile",
+    };
+
+    const issues = validatePluginManifest(manifest);
+    expect(issues.some((issue) => issue.field === "runtime")).toBe(true);
+  });
+
+  it("accepts whisper runtime without CTC vocab metadata", () => {
+    const manifest: PluginManifest = {
+      ...BUILTIN_ORT_ASR_PLUGIN,
+      pluginId: "test.asr.whisper",
+      runtime: "ort-whisper",
+      metadata: {},
     };
 
     const issues = validatePluginManifest(manifest);

--- a/src/plugins/contracts.ts
+++ b/src/plugins/contracts.ts
@@ -8,8 +8,9 @@ export interface PluginManifest {
   name: string;
   version: string;
   kind: PluginKind;
+  runtime: string;
   entrypointPath: string;
-  sha256: string;
+  hash: string;
   modelFamily?: string;
   sizeBytes?: number;
   license?: string;
@@ -33,21 +34,32 @@ export const BUILTIN_ORT_ASR_PLUGIN: PluginManifest = {
   name: "Built-in Medical ASR",
   version: "1.0.0",
   kind: "asr",
+  runtime: "ort-ctc",
   entrypointPath: "models/medasr_lasr_ctc_int8.onnx",
-  sha256: "05c1907f53d9dea3db23092e4d730f011ee400b3fb282d6af8443276dfb9d270",
+  hash: "05c1907f53d9dea3db23092e4d730f011ee400b3fb282d6af8443276dfb9d270",
   modelFamily: "medasr_lasr",
   metadata: {
     vocabPath: "models/medasr_lasr_vocab.json",
-    vocabSha256:
+    vocabHash:
       "631bd152b5beca9a74d21bd1c3ff53fecf63d10d11aae72e491cacdfbf69a756",
     lmPath: "models/lm_6.kenlm",
     kenlmWasmPath: "kenlm/kenlm.js",
+    runtimeConfig: {
+      asrType: "ctc",
+    },
   },
 };
 
-const SHA256_RE = /^[a-f0-9]{64}$/;
+const HASH_RE = /^[a-f0-9]{64}$/;
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
 const ID_RE = /^[A-Za-z0-9._-]{3,128}$/;
+
+function isSupportedRuntime(kind: PluginKind, runtime: string): boolean {
+  if (kind === "asr") {
+    return runtime === "ort-ctc" || runtime === "ort-whisper";
+  }
+  return runtime === "llamafile";
+}
 
 export function validatePluginManifest(
   manifest: PluginManifest,
@@ -72,6 +84,15 @@ export function validatePluginManifest(
     });
   }
 
+  if (!manifest.runtime.trim()) {
+    issues.push({ field: "runtime", message: "runtime is required" });
+  } else if (!isSupportedRuntime(manifest.kind, manifest.runtime.trim())) {
+    issues.push({
+      field: "runtime",
+      message: `runtime ${manifest.runtime} is not supported for kind ${manifest.kind}`,
+    });
+  }
+
   if (!manifest.entrypointPath.trim()) {
     issues.push({
       field: "entrypointPath",
@@ -79,14 +100,14 @@ export function validatePluginManifest(
     });
   }
 
-  if (!SHA256_RE.test(manifest.sha256)) {
+  if (!HASH_RE.test(manifest.hash)) {
     issues.push({
-      field: "sha256",
-      message: "sha256 must be 64 lowercase hex characters",
+      field: "hash",
+      message: "hash must be 64 lowercase hex characters",
     });
   }
 
-  if (manifest.kind === "asr") {
+  if (manifest.kind === "asr" && manifest.runtime === "ort-ctc") {
     const vocabPath = manifest.metadata?.vocabPath;
     if (typeof vocabPath !== "string" || !vocabPath.trim()) {
       issues.push({

--- a/src/plugins/platform.ts
+++ b/src/plugins/platform.ts
@@ -183,9 +183,7 @@ export class PluginPlatform {
     const sourcePath = await open({
       title: "Import Model File or Package",
       multiple: false,
-      filters: [
-        { name: "Model Files", extensions: ["llamafile", "onnx", "asrpkg"] },
-      ],
+      filters: [{ name: "Model Files", extensions: ["llamafile", "zip"] }],
     });
     if (typeof sourcePath !== "string") {
       return null;

--- a/src/plugins/runtime-adapter.test.ts
+++ b/src/plugins/runtime-adapter.test.ts
@@ -34,4 +34,31 @@ describe("runtime adapter", () => {
       ),
     ).toThrowError(/metadata\.vocabPath/);
   });
+
+  it("rejects unsupported ASR runtime values", () => {
+    expect(() =>
+      createRuntimeAdapter(
+        {
+          ...BUILTIN_ORT_ASR_PLUGIN,
+          pluginId: "bad.asr.runtime-unknown",
+          runtime: "custom-runtime",
+        },
+        OPTIONS,
+      ),
+    ).toThrowError(/Unsupported ASR runtime/);
+  });
+
+  it("rejects whisper runtime in web mode", () => {
+    expect(() =>
+      createRuntimeAdapter(
+        {
+          ...BUILTIN_ORT_ASR_PLUGIN,
+          pluginId: "bad.asr.runtime-whisper-web",
+          runtime: "ort-whisper",
+          metadata: {},
+        },
+        OPTIONS,
+      ),
+    ).toThrowError(/only supported in native desktop mode/);
+  });
 });

--- a/src/plugins/runtime-adapter.ts
+++ b/src/plugins/runtime-adapter.ts
@@ -76,14 +76,30 @@ export function createRuntimeAdapter(
 ): RuntimeAdapter {
   switch (manifest.kind) {
     case "asr": {
+      if (
+        manifest.runtime !== "ort-ctc" &&
+        manifest.runtime !== "ort-whisper"
+      ) {
+        throw new Error(
+          `Unsupported ASR runtime "${manifest.runtime}" for ${manifest.pluginId}`,
+        );
+      }
       const vocabPath = manifest.metadata?.vocabPath;
-      if (typeof vocabPath !== "string" || !vocabPath.trim()) {
+      if (
+        manifest.runtime === "ort-ctc" &&
+        (typeof vocabPath !== "string" || !vocabPath.trim())
+      ) {
         throw new Error(
           `Plugin ${manifest.pluginId} is missing metadata.vocabPath`,
         );
       }
       if (isTauri()) {
         return new NativeAsrRuntimeAdapter(manifest.pluginId, options.events);
+      }
+      if (manifest.runtime !== "ort-ctc") {
+        throw new Error(
+          `Runtime ${manifest.runtime} is only supported in native desktop mode`,
+        );
       }
       return new OrtRuntimeAdapter(
         manifest,
@@ -95,6 +111,11 @@ export function createRuntimeAdapter(
       );
     }
     case "llm":
+      if (manifest.runtime !== "llamafile") {
+        throw new Error(
+          `Unsupported LLM runtime "${manifest.runtime}" for ${manifest.pluginId}`,
+        );
+      }
       return new LlamafileRuntimeAdapter(manifest.pluginId);
     default:
       throw new Error(

--- a/src/plugins/service.test.ts
+++ b/src/plugins/service.test.ts
@@ -21,7 +21,7 @@ describe("PluginService", () => {
     expect(activeLlm).toBeNull();
   });
 
-  it("allows imported ONNX provider to become active ASR", async () => {
+  it("allows imported ASR provider to become active", async () => {
     const store = new NoopPluginRegistryStore();
     const service = new PluginService(store);
     await service.init();
@@ -31,7 +31,7 @@ describe("PluginService", () => {
       pluginId: "import.asr.ort.test",
       name: "Imported ASR",
       entrypointPath: "/tmp/test.onnx",
-      sha256: "1".repeat(64),
+      hash: "1".repeat(64),
     });
 
     await service.setActivePlugin("asr", "import.asr.ort.test");

--- a/src/plugins/store.test.ts
+++ b/src/plugins/store.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { NoopPluginRegistryStore } from "./store";
+
+describe("NoopPluginRegistryStore", () => {
+  it("imports .llamafile entries", async () => {
+    const store = new NoopPluginRegistryStore();
+
+    const manifest = await store.importFromPath({
+      sourcePath: "/tmp/test.llamafile",
+      displayName: "Test LLM",
+    });
+
+    expect(manifest.kind).toBe("llm");
+    expect(manifest.runtime).toBe("llamafile");
+    expect(manifest.name).toBe("Test LLM");
+  });
+
+  it("rejects .zip import in noop runtime", async () => {
+    const store = new NoopPluginRegistryStore();
+
+    await expect(
+      store.importFromPath({ sourcePath: "/tmp/asr-package.zip" }),
+    ).rejects.toThrowError(
+      /Zip package import is only available in desktop runtime/,
+    );
+  });
+
+  it("rejects unsupported extensions", async () => {
+    const store = new NoopPluginRegistryStore();
+
+    await expect(
+      store.importFromPath({ sourcePath: "/tmp/model.onnx" }),
+    ).rejects.toThrowError(/Only \.llamafile and \.zip imports are supported/);
+  });
+});

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -26,19 +26,6 @@ export interface PluginServiceHealth {
   endpoint: string | null;
 }
 
-function deriveOnnxVocabPath(sourcePath: string): string {
-  const fileName = sourcePath.split(/[\\/]/).pop() ?? "";
-  const baseName = fileName.replace(/\.onnx$/i, "");
-  const separator = sourcePath.includes("\\") ? "\\" : "/";
-  const index = Math.max(
-    sourcePath.lastIndexOf("/"),
-    sourcePath.lastIndexOf("\\"),
-  );
-  const dir = index >= 0 ? sourcePath.slice(0, index) : "";
-  const vocabName = `${baseName}_vocab.json`;
-  return dir ? `${dir}${separator}${vocabName}` : vocabName;
-}
-
 export interface PluginRegistryStore {
   init(): Promise<PluginRegistryState>;
   list(): Promise<PluginManifest[]>;
@@ -155,25 +142,19 @@ export class NoopPluginRegistryStore implements PluginRegistryStore {
 
     const fileName = sourcePath.split(/[\\/]/).pop() ?? "";
     const extension = fileName.toLowerCase().split(".").pop() ?? "";
-    if (
-      extension !== "llamafile" &&
-      extension !== "onnx" &&
-      extension !== "asrpkg"
-    ) {
-      throw new Error(
-        "Only .llamafile, .onnx, and .asrpkg imports are supported",
-      );
+    if (extension !== "llamafile" && extension !== "zip") {
+      throw new Error("Only .llamafile and .zip imports are supported");
     }
-    if (extension === "asrpkg") {
+    if (extension === "zip") {
       throw new Error(
-        "ASR package import is only available in desktop runtime",
+        "Zip package import is only available in desktop runtime",
       );
     }
 
     const isLlm = extension === "llamafile";
     const baseName =
       request.displayName?.trim() ||
-      fileName.replace(/\.(llamafile|onnx)$/i, "") ||
+      fileName.replace(/\.(llamafile|zip)$/i, "") ||
       "Imported Model";
     const timestamp = Date.now();
     const normalizedSlug = baseName.toLowerCase().replace(/[^a-z0-9]+/g, "-");
@@ -184,15 +165,11 @@ export class NoopPluginRegistryStore implements PluginRegistryStore {
       name: baseName,
       version: "1.0.0",
       kind: isLlm ? "llm" : "asr",
+      runtime: isLlm ? "llamafile" : "ort-ctc",
       entrypointPath: sourcePath,
-      sha256: "0".repeat(64),
+      hash: "0".repeat(64),
       installedAt: new Date().toISOString(),
-      metadata: isLlm
-        ? undefined
-        : {
-            vocabPath: deriveOnnxVocabPath(sourcePath),
-            vocabSha256: "0".repeat(64),
-          },
+      metadata: isLlm ? undefined : {},
     };
 
     await this.add(manifest);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1388,6 +1388,35 @@ body {
   border-color: var(--text-secondary);
 }
 
+#screen-settings .import-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: var(--space-2);
+}
+
+#screen-settings .import-progress .dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  animation: typingPulse 1.4s ease-in-out infinite;
+}
+
+#screen-settings .import-progress .dot:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+#screen-settings .import-progress .dot:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
+#screen-settings .import-progress-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-left: 2px;
+}
+
 #screen-settings .plugin-list-empty {
   font-size: 13px;
   color: var(--text-muted);


### PR DESCRIPTION
Summary
- add cleanup guard for destination assets when copying to avoid orphaned files on failure (import.rs)
- clarify hash key naming and semver validation behaviors plus align plugin registry/runtime settings as part of cleanup/config refinements
- bump import size caps (llamafile reference ~5GB) and adjust related frontend/runtime limits/tests to match the larger bundle
- refresh styles and platform/contracts/tests to reflect the updated plugin/runtime expectations

Testing
- Not run (not requested)