### PR TITLE
Update plugin UI labels and ASR defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,25 +392,14 @@
           <h2 class="view-title">Settings</h2>
         </header>
         <div class="view-body">
-          <h3>Dictation</h3>
-          <div class="plugin-list">
-            <div class="plugin-row">
-              <div class="plugin-info">
-                <div class="plugin-name">Medical Dictation</div>
-                <div class="plugin-meta">Built-in</div>
-              </div>
-              <div class="plugin-controls">
-                <label class="plugin-enabled-toggle">
-                  <input id="asrEnabled" type="checkbox" />
-                  <span>Enabled</span>
-                </label>
-              </div>
-            </div>
+          <h3>Plugins</h3>
+          <div id="pluginList" class="plugin-list"></div>
+          <div id="asrPluginSettingsPanel" class="plugin-settings-panel" hidden>
             <div class="plugin-row">
               <div class="plugin-info">
                 <div class="plugin-name">Enhanced Dictation</div>
-                <div class="plugin-meta">
-                  Experimental, may be slower on some devices
+                <div id="beamSearchMeta" class="plugin-meta">
+                  Improves quality but uses more memory
                 </div>
               </div>
               <div class="plugin-controls">
@@ -420,109 +409,107 @@
                 </label>
               </div>
             </div>
+            <details class="settings-advanced">
+              <summary>Advanced dictation tuning</summary>
+              <p id="asrSettingsStatus" class="status"></p>
+              <div class="settings-grid">
+                <label class="setting-field">
+                  <span>Silence RMS</span>
+                  <input
+                    id="asrSilenceRms"
+                    type="number"
+                    min="0.0001"
+                    max="0.05"
+                    step="0.0001"
+                  />
+                </label>
+                <label class="setting-field">
+                  <span>Silence Peak</span>
+                  <input
+                    id="asrSilencePeak"
+                    type="number"
+                    min="0.0001"
+                    max="0.2"
+                    step="0.0001"
+                  />
+                </label>
+                <label class="setting-field">
+                  <span>Silence Hangover (ms)</span>
+                  <input
+                    id="asrSilenceHangoverMs"
+                    type="range"
+                    min="100"
+                    max="2000"
+                    step="50"
+                  />
+                  <output id="asrSilenceHangoverOutput">500</output>
+                </label>
+                <label class="setting-field">
+                  <span>ORT Threads</span>
+                  <input
+                    id="asrOrtThreads"
+                    type="number"
+                    min="1"
+                    max="2"
+                    step="1"
+                  />
+                </label>
+                <label class="setting-field">
+                  <span>Beam Width</span>
+                  <input
+                    id="asrBeamWidth"
+                    type="number"
+                    min="1"
+                    max="32"
+                    step="1"
+                  />
+                </label>
+                <label class="setting-field">
+                  <span>LM Alpha</span>
+                  <input
+                    id="asrLmAlpha"
+                    type="number"
+                    min="0"
+                    max="3"
+                    step="0.1"
+                  />
+                </label>
+                <label class="setting-field">
+                  <span>LM Beta</span>
+                  <input
+                    id="asrLmBeta"
+                    type="number"
+                    min="-2"
+                    max="5"
+                    step="0.1"
+                  />
+                </label>
+                <label class="setting-field">
+                  <span>Min Token LogP</span>
+                  <input
+                    id="asrMinTokenLogp"
+                    type="number"
+                    min="-20"
+                    max="0"
+                    step="0.1"
+                  />
+                </label>
+                <label class="setting-field">
+                  <span>Beam Prune LogP</span>
+                  <input
+                    id="asrBeamPruneLogp"
+                    type="number"
+                    min="-30"
+                    max="0"
+                    step="0.1"
+                  />
+                </label>
+              </div>
+              <div class="actions" style="margin-top: var(--space-4)">
+                <button id="saveAsrSettingsBtn" type="button">Save</button>
+              </div>
+            </details>
           </div>
-          <details class="settings-advanced">
-            <summary>Advanced dictation tuning</summary>
-            <p id="asrSettingsStatus" class="status"></p>
-            <div class="settings-grid">
-              <label class="setting-field">
-                <span>Silence RMS</span>
-                <input
-                  id="asrSilenceRms"
-                  type="number"
-                  min="0.0001"
-                  max="0.05"
-                  step="0.0001"
-                />
-              </label>
-              <label class="setting-field">
-                <span>Silence Peak</span>
-                <input
-                  id="asrSilencePeak"
-                  type="number"
-                  min="0.0001"
-                  max="0.2"
-                  step="0.0001"
-                />
-              </label>
-              <label class="setting-field">
-                <span>Silence Hangover (ms)</span>
-                <input
-                  id="asrSilenceHangoverMs"
-                  type="range"
-                  min="100"
-                  max="2000"
-                  step="50"
-                />
-                <output id="asrSilenceHangoverOutput">500</output>
-              </label>
-              <label class="setting-field">
-                <span>ORT Threads</span>
-                <input
-                  id="asrOrtThreads"
-                  type="number"
-                  min="1"
-                  max="2"
-                  step="1"
-                />
-              </label>
-              <label class="setting-field">
-                <span>Beam Width</span>
-                <input
-                  id="asrBeamWidth"
-                  type="number"
-                  min="1"
-                  max="32"
-                  step="1"
-                />
-              </label>
-              <label class="setting-field">
-                <span>LM Alpha</span>
-                <input
-                  id="asrLmAlpha"
-                  type="number"
-                  min="0"
-                  max="3"
-                  step="0.1"
-                />
-              </label>
-              <label class="setting-field">
-                <span>LM Beta</span>
-                <input
-                  id="asrLmBeta"
-                  type="number"
-                  min="-2"
-                  max="5"
-                  step="0.1"
-                />
-              </label>
-              <label class="setting-field">
-                <span>Min Token LogP</span>
-                <input
-                  id="asrMinTokenLogp"
-                  type="number"
-                  min="-20"
-                  max="0"
-                  step="0.1"
-                />
-              </label>
-              <label class="setting-field">
-                <span>Beam Prune LogP</span>
-                <input
-                  id="asrBeamPruneLogp"
-                  type="number"
-                  min="-30"
-                  max="0"
-                  step="0.1"
-                />
-              </label>
-            </div>
-            <div class="actions" style="margin-top: var(--space-4)">
-              <button id="saveAsrSettingsBtn" type="button">Save</button>
-            </div>
-          </details>
-          <h3>Plugins</h3>
-          <div id="pluginList" class="plugin-list"></div>
           <div class="actions">
             <button id="importPluginBtn" type="button">Import Plugin</button>
             <div id="importProgress" class="import-progress" hidden>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.3",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -141,7 +141,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.3",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -242,6 +242,29 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.114",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -435,6 +458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +503,26 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -636,12 +688,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -660,11 +736,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.114",
 ]
@@ -687,6 +774,37 @@ checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -808,6 +926,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "transcribe-rs",
  "ureq 2.12.1",
  "zip",
 ]
@@ -838,6 +957,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
@@ -884,6 +1009,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -1038,6 +1176,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -1499,6 +1643,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1713,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1805,6 +1970,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,6 +1988,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1927,6 +2112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,7 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -1973,6 +2164,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2182,12 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2082,6 +2289,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2213,6 +2426,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-complex"
@@ -2857,7 +3080,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -3247,6 +3470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,6 +3500,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -3278,7 +3520,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3543,7 +3785,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -4177,7 +4419,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -4190,6 +4432,15 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4470,6 +4721,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transcribe-rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e3bf6e1dd4909268796bdf3794fb6fda70f4a0e5a80e2e56cd3fc213a11586"
+dependencies = [
+ "derive_builder",
+ "env_logger",
+ "hound",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -4981,6 +5248,39 @@ dependencies = [
  "thiserror 2.0.18",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6fc553156b521663bfa8e713e7ad58c7ca262d46de9998cd7f2e4de5ba0d9"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bab42b2c319e3a1e0280137c59368072348d3277873c7588b6466a127dca58"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
 ]
 
 [[package]]
@@ -5641,7 +5941,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.3",
  "serde",
  "serde_repr",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ ort = "2.0.0-rc.11"
 ndarray = "0.16"
 realfft = "3"
 zip = { version = "8", default-features = false, features = ["deflate"] }
+transcribe-rs = { version = "0.2.5", default-features = false, features = ["whisper"] }
 
 [[bin]]
 name = "benchmark-asr"

--- a/src-tauri/src/bin/benchmark_asr.rs
+++ b/src-tauri/src/bin/benchmark_asr.rs
@@ -281,8 +281,7 @@ fn merge_chunk_text(current_text: &str, next_text: &str) -> String {
         if suffix.is_empty() {
             return current_text.to_string();
         }
-        if overlap_count == 1
-            && normalize_merge_token(next_words[0]).len() <= SHORT_STRIDE_WORD_LEN
+        if overlap_count == 1 && normalize_merge_token(next_words[0]).len() <= SHORT_STRIDE_WORD_LEN
         {
             return format!("{current_text} {suffix}");
         }
@@ -451,10 +450,7 @@ fn main() {
     println!("ASR Benchmark (native Rust ORT)");
     println!("===============================");
     println!("Audio: {}", cli.audio_path);
-    println!(
-        "Reference: \"{}\"",
-        truncate(&cli.reference, 60)
-    );
+    println!("Reference: \"{}\"", truncate(&cli.reference, 60));
     println!();
 
     // Load audio
@@ -471,17 +467,17 @@ fn main() {
     // Load ASR model
     println!("Model: {}", cli.model_path);
     println!("Loading ASR model...");
-    let running = asr::load_session(&cli.model_path, &cli.vocab_path).unwrap_or_else(|e| {
+    let running = asr::load_ctc_session(&cli.model_path, &cli.vocab_path).unwrap_or_else(|e| {
         eprintln!("Failed to load ASR: {e}");
         std::process::exit(1);
     });
-    let session = &running.0;
+    let session = &running;
     println!("  Model loaded");
     println!();
 
     // Chunk configs: (chunk_secs, stride_secs)
     let chunk_configs: Vec<(f64, f64)> = vec![
-        (6.0, 1.5),   // app default
+        (6.0, 1.5), // app default
         (10.0, 2.0),
         (15.0, 1.5),
         (20.0, 2.0),
@@ -600,10 +596,6 @@ fn main() {
         .iter()
         .min_by(|a, b| a.wer.partial_cmp(&b.wer).unwrap())
     {
-        println!(
-            "Best: {} — WER={:.1}%",
-            best.label,
-            best.wer * 100.0
-        );
+        println!("Best: {} — WER={:.1}%", best.label, best.wer * 100.0);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod plugins;
 mod storage;
+mod util;
 
 use serde::Serialize;
 use tauri::WebviewWindow;

--- a/src-tauri/src/plugins/asr.rs
+++ b/src-tauri/src/plugins/asr.rs
@@ -1,10 +1,13 @@
 use std::collections::{HashMap, HashSet};
 use std::f64::consts::PI;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use ort::value::Tensor;
 use realfft::{RealFftPlanner, RealToComplex};
 use serde::Deserialize;
+use transcribe_rs::engines::whisper::{WhisperEngine, WhisperInferenceParams, WhisperModelParams};
+use transcribe_rs::TranscriptionEngine;
 
 use super::RuntimeExecuteResult;
 
@@ -30,7 +33,7 @@ pub struct AsrVocab {
     special_ids: HashSet<usize>,
 }
 
-pub struct AsrSession {
+pub struct CtcSession {
     session: Mutex<ort::session::Session>,
     vocab: AsrVocab,
     mel_filterbank: Vec<f64>,
@@ -38,7 +41,23 @@ pub struct AsrSession {
     fft_plan: Arc<dyn RealToComplex<f64>>,
 }
 
-pub struct RunningAsr(pub Arc<AsrSession>);
+pub struct WhisperSession {
+    engine: Mutex<WhisperEngine>,
+    inference_params: WhisperInferenceParams,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WhisperRuntimeConfig {
+    pub language: Option<String>,
+    pub translate: bool,
+    pub initial_prompt: Option<String>,
+}
+
+#[derive(Clone)]
+pub enum RunningAsr {
+    Ctc(Arc<CtcSession>),
+    Whisper(Arc<WhisperSession>),
+}
 
 fn hertz_to_mel(freq: f64) -> f64 {
     1127.0 * (1.0 + freq / 700.0).ln()
@@ -215,11 +234,7 @@ fn decode_ctc(logits: &[f32], frames: usize, vocab_size: usize, vocab: &AsrVocab
         prev_token = best_idx as isize;
     }
 
-    result
-        .join("")
-        .replace('\u{2581}', " ")
-        .trim()
-        .to_string()
+    result.join("").replace('\u{2581}', " ").trim().to_string()
 }
 
 fn normalize_section_headers(text: &str) -> String {
@@ -293,10 +308,7 @@ fn strip_leading_bracket_artifact(text: &str) -> String {
     }
 }
 
-pub fn load_session(
-    model_path: &str,
-    vocab_path: &str,
-) -> Result<RunningAsr, String> {
+pub fn load_ctc_session(model_path: &str, vocab_path: &str) -> Result<RunningAsr, String> {
     // Load vocab
     let vocab_bytes = std::fs::read(vocab_path)
         .map_err(|e| format!("Failed to read vocab file {vocab_path}: {e}"))?;
@@ -325,7 +337,7 @@ pub fn load_session(
     let mut planner = RealFftPlanner::<f64>::new();
     let fft_plan = planner.plan_fft_forward(N_FFT);
 
-    Ok(RunningAsr(Arc::new(AsrSession {
+    Ok(RunningAsr::Ctc(Arc::new(CtcSession {
         session: Mutex::new(session),
         vocab,
         mel_filterbank,
@@ -334,10 +346,41 @@ pub fn load_session(
     })))
 }
 
-pub fn transcribe(
-    asr: &AsrSession,
-    samples: &[f32],
-) -> Result<RuntimeExecuteResult, String> {
+pub(super) fn normalize_optional_text(value: Option<String>) -> Option<String> {
+    value
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+pub fn load_whisper_session(
+    model_path: &str,
+    runtime_config: WhisperRuntimeConfig,
+) -> Result<RunningAsr, String> {
+    let mut engine = WhisperEngine::new();
+    let params = WhisperModelParams { use_gpu: false };
+    engine
+        .load_model_with_params(Path::new(model_path), params)
+        .map_err(|e| format!("Failed to load Whisper model {model_path}: {e}"))?;
+
+    let mut inference_params = WhisperInferenceParams::default();
+    inference_params.language = normalize_optional_text(runtime_config.language);
+    inference_params.translate = runtime_config.translate;
+    inference_params.initial_prompt = normalize_optional_text(runtime_config.initial_prompt);
+
+    Ok(RunningAsr::Whisper(Arc::new(WhisperSession {
+        engine: Mutex::new(engine),
+        inference_params,
+    })))
+}
+
+pub fn transcribe(asr: &RunningAsr, samples: &[f32]) -> Result<RuntimeExecuteResult, String> {
+    match asr {
+        RunningAsr::Ctc(session) => transcribe_ctc(session, samples),
+        RunningAsr::Whisper(session) => transcribe_whisper(session, samples),
+    }
+}
+
+fn transcribe_ctc(asr: &CtcSession, samples: &[f32]) -> Result<RuntimeExecuteResult, String> {
     let (features, frames) = extract_mel_features(
         samples,
         &asr.mel_filterbank,
@@ -390,9 +433,23 @@ pub fn transcribe(
     Ok(RuntimeExecuteResult { text })
 }
 
-pub(super) fn unload(
-    running: &mut HashMap<String, RunningAsr>,
-    plugin_id: &str,
-) {
+fn transcribe_whisper(
+    asr: &WhisperSession,
+    samples: &[f32],
+) -> Result<RuntimeExecuteResult, String> {
+    let mut engine = asr
+        .engine
+        .lock()
+        .map_err(|e| format!("Failed to lock Whisper session: {e}"))?;
+    let result = engine
+        .transcribe_samples(samples.to_vec(), Some(asr.inference_params.clone()))
+        .map_err(|e| format!("Whisper inference failed: {e}"))?;
+
+    Ok(RuntimeExecuteResult {
+        text: result.text.trim().to_string(),
+    })
+}
+
+pub(super) fn unload(running: &mut HashMap<String, RunningAsr>, plugin_id: &str) {
     running.remove(plugin_id);
 }

--- a/src-tauri/src/plugins/import.rs
+++ b/src-tauri/src/plugins/import.rs
@@ -418,6 +418,13 @@ fn resolve_extracted_asset_path(root: &Path, value: &str) -> Result<InstallAsset
     })
 }
 
+fn has_extension(path: &Path, expected: &str) -> bool {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.eq_ignore_ascii_case(expected))
+        .unwrap_or(false)
+}
+
 fn insert_default_llm_metadata(fields: &mut Map<String, Value>) {
     fields.insert(
         "serviceStartArgs".to_string(),
@@ -434,7 +441,7 @@ fn insert_default_llm_metadata(fields: &mut Map<String, Value>) {
 }
 
 fn default_asr_runtime_config(runtime: &str) -> Value {
-    let asr_type = if runtime == "ort-whisper" {
+    let asr_type = if runtime == "whisper" {
         "whisper"
     } else {
         "ctc"
@@ -580,6 +587,13 @@ fn load_zip_package(extract_root: &Path) -> Result<ParsedZipPackage, String> {
                     relative_path: wasm_relative,
                 });
             }
+        }
+    } else if kind == PluginKind::Asr && runtime == "whisper" {
+        // transcribe-rs WhisperEngine loads a single GGML model file.
+        if !has_extension(&entrypoint.relative_path, "bin") {
+            return Err(
+                "ASR runtime whisper requires entrypoint to be a GGML .bin file".to_string(),
+            );
         }
     }
 
@@ -889,6 +903,65 @@ mod tests {
         assert_eq!(parsed.version, "1.2.3");
         assert_eq!(parsed.assets.len(), 2);
         assert_eq!(parsed.supplemental_assets.len(), 1);
+    }
+
+    #[test]
+    fn load_zip_package_accepts_valid_whisper_manifest() {
+        let dir = TempDir::new("valid-whisper");
+        write_file(
+            dir.path().join("models/whisper-medium-q4_1.bin").as_path(),
+            b"ggml",
+        );
+
+        let manifest = format!(
+            r#"{{
+  "schema": "{schema}",
+  "kind": "asr",
+  "runtime": "whisper",
+  "name": "Zip Whisper ASR",
+  "version": "1.0.0",
+  "entrypoint": "models/whisper-medium-q4_1.bin",
+  "runtimeConfig": {{
+    "asrType": "whisper",
+    "language": "en"
+  }}
+}}"#,
+            schema = PACKAGE_SCHEMA_V1
+        );
+        write_file(
+            dir.path().join(PACKAGE_MANIFEST_FILE).as_path(),
+            manifest.as_bytes(),
+        );
+
+        let parsed = load_zip_package(dir.path()).expect("expected valid whisper package");
+        assert_eq!(parsed.runtime, "whisper");
+        assert_eq!(parsed.assets.len(), 0);
+    }
+
+    #[test]
+    fn load_zip_package_rejects_whisper_without_bin_entrypoint() {
+        let dir = TempDir::new("invalid-whisper-entrypoint");
+        write_file(dir.path().join("models/model.onnx").as_path(), b"onnx");
+
+        let manifest = format!(
+            r#"{{
+  "schema": "{schema}",
+  "kind": "asr",
+  "runtime": "whisper",
+  "name": "Zip Whisper ASR",
+  "version": "1.0.0",
+  "entrypoint": "models/model.onnx"
+}}"#,
+            schema = PACKAGE_SCHEMA_V1
+        );
+        write_file(
+            dir.path().join(PACKAGE_MANIFEST_FILE).as_path(),
+            manifest.as_bytes(),
+        );
+
+        let error =
+            load_zip_package(dir.path()).expect_err("expected whisper entrypoint format rejection");
+        assert!(error.contains("GGML .bin"));
     }
 
     #[test]

--- a/src-tauri/src/plugins/llamafile.rs
+++ b/src-tauri/src/plugins/llamafile.rs
@@ -1,16 +1,16 @@
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
 
+use super::registry::{
+    ensure_registry, load_registry, plugin_paths, resolve_entrypoint, resolve_plugin,
+};
 use super::{
     err_to_string, parse_string_array_field, parse_string_field, PluginKind, PluginRuntimeState,
     RuntimeExecuteResult, RuntimeHealth,
-};
-use super::registry::{
-    ensure_registry, load_registry, plugin_paths, resolve_entrypoint, resolve_plugin,
 };
 
 pub(super) struct RunningLlamafile {
@@ -72,8 +72,8 @@ fn normalize_http_path(path: &str, default_path: &str) -> String {
 }
 
 fn service_health_path(metadata: &Option<Value>) -> String {
-    let configured = parse_string_field(metadata, "serviceHealthPath")
-        .unwrap_or_else(|| "/health".to_string());
+    let configured =
+        parse_string_field(metadata, "serviceHealthPath").unwrap_or_else(|| "/health".to_string());
     normalize_http_path(&configured, "/health")
 }
 
@@ -89,15 +89,14 @@ fn build_url(endpoint: &str, path: &str) -> String {
 }
 
 fn service_start_args(metadata: &Option<Value>, port: u16) -> Vec<String> {
-    let templates = parse_string_array_field(metadata, "serviceStartArgs")
-        .unwrap_or_else(|| {
-            vec![
-                "--server".to_string(),
-                "--port".to_string(),
-                "{port}".to_string(),
-                "--nobrowser".to_string(),
-            ]
-        });
+    let templates = parse_string_array_field(metadata, "serviceStartArgs").unwrap_or_else(|| {
+        vec![
+            "--server".to_string(),
+            "--port".to_string(),
+            "{port}".to_string(),
+            "--nobrowser".to_string(),
+        ]
+    });
     templates
         .into_iter()
         .map(|template| template.replace("{port}", &port.to_string()))

--- a/src-tauri/src/plugins/manifest_utils.rs
+++ b/src-tauri/src/plugins/manifest_utils.rs
@@ -2,7 +2,7 @@ use super::PluginKind;
 
 pub(super) fn is_supported_runtime(kind: &PluginKind, runtime: &str) -> bool {
     match kind {
-        PluginKind::Asr => matches!(runtime, "ort-ctc" | "ort-whisper"),
+        PluginKind::Asr => matches!(runtime, "ort-ctc" | "whisper"),
         PluginKind::Llm => matches!(runtime, "llamafile"),
     }
 }

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -7,11 +7,8 @@ mod registry;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs::{self, File};
-use std::io::{self, Write};
-use std::path::Path;
+use std::fs;
 use std::sync::{Mutex, MutexGuard};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager, State};
 
 use asr::RunningAsr;
@@ -137,57 +134,6 @@ fn err_to_string(error: impl std::fmt::Display) -> String {
     error.to_string()
 }
 
-fn unique_suffix() -> String {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{nanos}-{}", std::process::id())
-}
-
-fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    let Some(parent) = path.parent() else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Path has no parent directory",
-        ));
-    };
-    fs::create_dir_all(parent)?;
-
-    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Path has no valid file name",
-        ));
-    };
-
-    let tmp_path = parent.join(format!(".{file_name}.tmp-{}", unique_suffix()));
-    {
-        let mut file = File::create(&tmp_path)?;
-        file.write_all(bytes)?;
-        file.sync_all()?;
-    }
-
-    if let Err(rename_error) = fs::rename(&tmp_path, path) {
-        if path.exists() {
-            fs::remove_file(path)?;
-            fs::rename(&tmp_path, path)?;
-            return Ok(());
-        }
-
-        let _ = fs::remove_file(&tmp_path);
-        return Err(rename_error);
-    }
-
-    Ok(())
-}
-
-fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
-    let encoded = serde_json::to_vec_pretty(value)
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    write_bytes_atomic(path, &encoded)
-}
-
 fn parse_string_field(metadata: &Option<Value>, field: &str) -> Option<String> {
     let Some(Value::Object(map)) = metadata else {
         return None;
@@ -214,6 +160,32 @@ fn parse_string_array_field(metadata: &Option<Value>, field: &str) -> Option<Vec
         args.push(text.clone());
     }
     Some(args)
+}
+
+fn parse_runtime_config_string_field(metadata: &Option<Value>, field: &str) -> Option<String> {
+    let Some(Value::Object(map)) = metadata else {
+        return None;
+    };
+    let Some(Value::Object(runtime_config)) = map.get("runtimeConfig") else {
+        return None;
+    };
+    let Some(Value::String(value)) = runtime_config.get(field) else {
+        return None;
+    };
+    Some(value.clone())
+}
+
+fn parse_runtime_config_bool_field(metadata: &Option<Value>, field: &str) -> Option<bool> {
+    let Some(Value::Object(map)) = metadata else {
+        return None;
+    };
+    let Some(Value::Object(runtime_config)) = map.get("runtimeConfig") else {
+        return None;
+    };
+    let Some(Value::Bool(value)) = runtime_config.get(field) else {
+        return None;
+    };
+    Some(*value)
 }
 
 // -- Tauri commands --
@@ -506,28 +478,45 @@ pub async fn plugin_asr_load(app: AppHandle, plugin_id: String) -> Result<Runtim
         if plugin.kind != PluginKind::Asr {
             return Err(format!("Plugin {plugin_id} is not an ASR plugin"));
         }
-        if plugin.runtime != "ort-ctc" {
-            return Err(format!(
-                "ASR runtime {} is not supported yet for {plugin_id}",
-                plugin.runtime
-            ));
-        }
 
         let model_path = resolve_entrypoint(&app, &plugin.entrypoint_path)?;
         if !model_path.exists() {
             return Err(format!("Model file not found: {}", model_path.display()));
         }
 
-        let vocab_rel = parse_string_field(&plugin.metadata, "vocabPath")
-            .ok_or_else(|| format!("Plugin {plugin_id} missing metadata.vocabPath"))?;
-        let vocab_path = resolve_entrypoint(&app, &vocab_rel)?;
-        if !vocab_path.exists() {
-            return Err(format!("Vocab file not found: {}", vocab_path.display()));
-        }
-
         let model_str = model_path.to_string_lossy().to_string();
-        let vocab_str = vocab_path.to_string_lossy().to_string();
-        let session = asr::load_session(&model_str, &vocab_str)?;
+        let session = match plugin.runtime.as_str() {
+            "ort-ctc" => {
+                let vocab_rel = parse_string_field(&plugin.metadata, "vocabPath")
+                    .ok_or_else(|| format!("Plugin {plugin_id} missing metadata.vocabPath"))?;
+                let vocab_path = resolve_entrypoint(&app, &vocab_rel)?;
+                if !vocab_path.exists() {
+                    return Err(format!("Vocab file not found: {}", vocab_path.display()));
+                }
+
+                let vocab_str = vocab_path.to_string_lossy().to_string();
+                asr::load_ctc_session(&model_str, &vocab_str)?
+            }
+            "whisper" => {
+                let whisper_config = asr::WhisperRuntimeConfig {
+                    language: asr::normalize_optional_text(parse_runtime_config_string_field(
+                        &plugin.metadata,
+                        "language",
+                    )),
+                    translate: parse_runtime_config_bool_field(&plugin.metadata, "translate")
+                        .unwrap_or(false),
+                    initial_prompt: asr::normalize_optional_text(
+                        parse_runtime_config_string_field(&plugin.metadata, "initialPrompt"),
+                    ),
+                };
+                asr::load_whisper_session(&model_str, whisper_config)?
+            }
+            runtime => {
+                return Err(format!(
+                    "ASR runtime {runtime} is not supported yet for {plugin_id}",
+                ));
+            }
+        };
 
         let mut running = runtime_state.lock_running_asr();
         running.insert(plugin_id.clone(), session);
@@ -550,14 +539,14 @@ pub async fn plugin_asr_transcribe(
     plugin_id: String,
     samples: Vec<f32>,
 ) -> Result<RuntimeExecuteResult, String> {
-    // Grab a clone of the Arc<AsrSession> so we don't hold the mutex during inference
+    // Grab a clone so we don't hold the runtime-state lock during inference.
     let session = {
         let runtime_state = app.state::<PluginRuntimeState>();
         let running = runtime_state.lock_running_asr();
-        let Some(running_asr) = running.get(&plugin_id) else {
+        let Some(running_asr) = running.get(&plugin_id).cloned() else {
             return Err(format!("ASR session not loaded for {plugin_id}"));
         };
-        running_asr.0.clone()
+        running_asr
     };
 
     tauri::async_runtime::spawn_blocking(move || asr::transcribe(&session, &samples))

--- a/src-tauri/src/plugins/registry.rs
+++ b/src-tauri/src/plugins/registry.rs
@@ -4,11 +4,12 @@ use std::fs;
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
+use crate::util::write_json_atomic;
+
 use super::{
     err_to_string,
     manifest_utils::{is_supported_runtime, is_valid_semver},
-    parse_string_field, write_json_atomic, ActivePlugins, PluginKind, PluginManifest,
-    PluginRegistryState,
+    parse_string_field, ActivePlugins, PluginKind, PluginManifest, PluginRegistryState,
 };
 
 const REGISTRY_FORMAT: u8 = 1;
@@ -57,7 +58,7 @@ pub(super) fn save_registry(
 pub(super) fn builtin_ort_asr_plugin() -> PluginManifest {
     PluginManifest {
         plugin_id: BUILTIN_ORT_ASR_PLUGIN_ID.to_string(),
-        name: "Built-in Medical ASR".to_string(),
+        name: "Google MedASR".to_string(),
         version: "1.0.0".to_string(),
         kind: PluginKind::Asr,
         runtime: "ort-ctc".to_string(),
@@ -68,6 +69,10 @@ pub(super) fn builtin_ort_asr_plugin() -> PluginManifest {
         license: None,
         installed_at: None,
         metadata: Some(Value::Object(Map::from_iter([
+            (
+                "language".to_string(),
+                Value::String("en".to_string()),
+            ),
             (
                 "vocabPath".to_string(),
                 Value::String("models/medasr_lasr_vocab.json".to_string()),

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -2,12 +2,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::fs::{self, File};
-use std::io::{self, Write};
+use std::io;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager};
 use zip::write::SimpleFileOptions;
 use zip::CompressionMethod;
+
+use crate::util::{write_bytes_atomic, write_json_atomic};
 
 const STORAGE_FORMAT: u8 = 1;
 const RECORDING_FILE_NAME: &str = "recording.json";
@@ -125,57 +126,6 @@ fn storage_paths(app: &AppHandle) -> Result<StoragePaths, String> {
 fn ensure_storage(paths: &StoragePaths) -> Result<(), String> {
     fs::create_dir_all(&paths.recordings_dir).map_err(err_to_string)?;
     Ok(())
-}
-
-fn unique_suffix() -> String {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{nanos}-{}", std::process::id())
-}
-
-fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    let Some(parent) = path.parent() else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Path has no parent directory",
-        ));
-    };
-    fs::create_dir_all(parent)?;
-
-    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Path has no valid file name",
-        ));
-    };
-
-    let tmp_path = parent.join(format!(".{file_name}.tmp-{}", unique_suffix()));
-    {
-        let mut file = File::create(&tmp_path)?;
-        file.write_all(bytes)?;
-        file.sync_all()?;
-    }
-
-    if let Err(rename_error) = fs::rename(&tmp_path, path) {
-        if path.exists() {
-            fs::remove_file(path)?;
-            fs::rename(&tmp_path, path)?;
-            return Ok(());
-        }
-
-        let _ = fs::remove_file(&tmp_path);
-        return Err(rename_error);
-    }
-
-    Ok(())
-}
-
-fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
-    let encoded = serde_json::to_vec_pretty(value)
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    write_bytes_atomic(path, &encoded)
 }
 
 fn recording_dir(paths: &StoragePaths, recording_id: &str) -> PathBuf {
@@ -354,7 +304,9 @@ fn validate_recording(recording: &Recording) -> Result<(), String> {
     Ok(())
 }
 
-fn list_recording_entries_from_files(paths: &StoragePaths) -> Result<Vec<RecordingIndexEntry>, String> {
+fn list_recording_entries_from_files(
+    paths: &StoragePaths,
+) -> Result<Vec<RecordingIndexEntry>, String> {
     let mut recordings = Vec::new();
     if !paths.recordings_dir.exists() {
         return Ok(recordings);
@@ -648,7 +600,10 @@ pub fn storage_write_attachment_text(
     write_bytes_atomic(&file_path, request.text.as_bytes()).map_err(err_to_string)?;
 
     Ok(WriteAttachmentTextResult {
-        path: format!("recordings/{}/attachments/{}", request.recording_id, file_name),
+        path: format!(
+            "recordings/{}/attachments/{}",
+            request.recording_id, file_name
+        ),
         size_bytes: request.text.len(),
     })
 }

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,0 +1,56 @@
+use serde::Serialize;
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_suffix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{nanos}-{}", std::process::id())
+}
+
+pub fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Path has no parent directory",
+        ));
+    };
+    fs::create_dir_all(parent)?;
+
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Path has no valid file name",
+        ));
+    };
+
+    let tmp_path = parent.join(format!(".{file_name}.tmp-{}", unique_suffix()));
+    {
+        let mut file = File::create(&tmp_path)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+
+    if let Err(rename_error) = fs::rename(&tmp_path, path) {
+        if path.exists() {
+            fs::remove_file(path)?;
+            fs::rename(&tmp_path, path)?;
+            return Ok(());
+        }
+
+        let _ = fs::remove_file(&tmp_path);
+        return Err(rename_error);
+    }
+
+    Ok(())
+}
+
+pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    let encoded = serde_json::to_vec_pretty(value)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    write_bytes_atomic(path, &encoded)
+}

--- a/src/app/asr-settings-controller.ts
+++ b/src/app/asr-settings-controller.ts
@@ -15,7 +15,6 @@ export class AsrSettingsController {
 
   private readonly saveBtn: HTMLButtonElement;
   private readonly statusEl: HTMLElement;
-  private readonly asrEnabledInput: HTMLInputElement;
   private readonly beamSearchEnabledInput: HTMLInputElement;
   private readonly silenceRmsInput: HTMLInputElement;
   private readonly silencePeakInput: HTMLInputElement;
@@ -34,7 +33,6 @@ export class AsrSettingsController {
 
     this.saveBtn = mustBtn("saveAsrSettingsBtn");
     this.statusEl = mustEl("asrSettingsStatus");
-    this.asrEnabledInput = mustInput("asrEnabled");
     this.beamSearchEnabledInput = mustInput("asrBeamSearchEnabled");
     this.silenceRmsInput = mustInput("asrSilenceRms");
     this.silencePeakInput = mustInput("asrSilencePeak");
@@ -47,9 +45,6 @@ export class AsrSettingsController {
     this.minTokenLogpInput = mustInput("asrMinTokenLogp");
     this.beamPruneLogpInput = mustInput("asrBeamPruneLogp");
 
-    this.asrEnabledInput.addEventListener("change", () => {
-      this.updateFieldState();
-    });
     this.beamSearchEnabledInput.addEventListener("change", () => {
       this.updateFieldState();
     });
@@ -62,7 +57,6 @@ export class AsrSettingsController {
   }
 
   populate(settings: AsrSettings): void {
-    this.asrEnabledInput.checked = settings.asrEnabled;
     this.beamSearchEnabledInput.checked =
       settings.runtimeConfig.decode.beamSearchEnabled;
     this.silenceRmsInput.value = String(settings.silenceRms);
@@ -93,7 +87,6 @@ export class AsrSettingsController {
 
     try {
       const next = sanitizeAsrSettings({
-        asrEnabled: this.asrEnabledInput.checked,
         silenceRms: this.silenceRmsInput.valueAsNumber,
         silencePeak: this.silencePeakInput.valueAsNumber,
         silenceHangoverMs: this.silenceHangoverInput.valueAsNumber,
@@ -123,16 +116,14 @@ export class AsrSettingsController {
   }
 
   private updateFieldState(): void {
-    const asrEnabled = this.asrEnabledInput.checked;
     const beamEnabled = this.beamSearchEnabledInput.checked;
 
-    this.beamSearchEnabledInput.disabled = !asrEnabled;
-    this.silenceRmsInput.disabled = !asrEnabled;
-    this.silencePeakInput.disabled = !asrEnabled;
-    this.silenceHangoverInput.disabled = !asrEnabled;
-    this.ortThreadsInput.disabled = !asrEnabled;
+    this.silenceRmsInput.disabled = false;
+    this.silencePeakInput.disabled = false;
+    this.silenceHangoverInput.disabled = false;
+    this.ortThreadsInput.disabled = false;
 
-    const decodeEnabled = asrEnabled && beamEnabled;
+    const decodeEnabled = beamEnabled && !this.beamSearchEnabledInput.disabled;
     this.beamWidthInput.disabled = !decodeEnabled;
     this.lmAlphaInput.disabled = !decodeEnabled;
     this.lmBetaInput.disabled = !decodeEnabled;

--- a/src/app/dictation-controller.ts
+++ b/src/app/dictation-controller.ts
@@ -18,6 +18,12 @@ export interface DictationControllerOptions {
   onLevel?: (rms: number) => void;
 }
 
+export interface DictationVadSettings {
+  silenceRms: number;
+  silencePeak: number;
+  silenceHangoverMs: number;
+}
+
 const VAD_FRAME_SAMPLES = 2048;
 const VAD_SPEECH_ONSET_MS = 150;
 const VAD_MAX_SEGMENT_SECS = 18;
@@ -31,8 +37,15 @@ export class DictationController {
   private metricChunkId = 0;
   private overloadDropCount = 0;
   private segmenter: VadSegmenter | null = null;
+  private silenceRms: number;
+  private silencePeak: number;
+  private silenceHangoverMs: number;
 
-  constructor(private readonly options: DictationControllerOptions) {}
+  constructor(private readonly options: DictationControllerOptions) {
+    this.silenceRms = options.silenceRms;
+    this.silencePeak = options.silencePeak;
+    this.silenceHangoverMs = options.silenceHangoverMs;
+  }
 
   get isRecording(): boolean {
     return this.isRecordingValue;
@@ -42,23 +55,13 @@ export class DictationController {
     return this.options.pluginPlatform.isAsrReady();
   }
 
-  async loadModel(): Promise<boolean> {
-    if (this.options.pluginPlatform.isAsrReady()) {
-      this.options.onStatus("Model already loaded");
-      return true;
+  setVadSettings(settings: DictationVadSettings): void {
+    if (this.isRecordingValue) {
+      return;
     }
-
-    this.options.onStatus("Loading model in background...");
-
-    try {
-      const provider = await this.options.pluginPlatform.loadAsr();
-      this.options.onStatus(`${provider.name} loaded. Ready to record.`);
-      return true;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.options.onStatus(`Load failed: ${message}`);
-      return false;
-    }
+    this.silenceRms = settings.silenceRms;
+    this.silencePeak = settings.silencePeak;
+    this.silenceHangoverMs = settings.silenceHangoverMs;
   }
 
   /** Returns the recording state after the toggle attempt. */
@@ -86,10 +89,10 @@ export class DictationController {
           const vadConfig: VadSegmenterConfig = {
             sampleRate: this.options.sampleRate,
             frameSamples: VAD_FRAME_SAMPLES,
-            silenceRms: this.options.silenceRms,
-            silencePeak: this.options.silencePeak,
+            silenceRms: this.silenceRms,
+            silencePeak: this.silencePeak,
             speechOnsetMs: VAD_SPEECH_ONSET_MS,
-            silenceHangoverMs: this.options.silenceHangoverMs,
+            silenceHangoverMs: this.silenceHangoverMs,
             maxSegmentSecs: VAD_MAX_SEGMENT_SECS,
             preRollMs: VAD_PRE_ROLL_MS,
           };

--- a/src/asr/settings.test.ts
+++ b/src/asr/settings.test.ts
@@ -63,12 +63,10 @@ describe("readAsrSettings", () => {
     const storage = createMemoryStorage({
       "toru.silence.hangover.ms": "nope",
       "toru.asr.decode.beam.width": "n/a",
-      "toru.asr.enabled": "wat",
       "toru.asr.decode.beam.enabled": "wat",
     });
 
     const settings = readAsrSettings(storage);
-    expect(settings.asrEnabled).toBe(DEFAULT_ASR_SETTINGS.asrEnabled);
     expect(settings.runtimeConfig.decode.beamSearchEnabled).toBe(
       DEFAULT_ASR_SETTINGS.runtimeConfig.decode.beamSearchEnabled,
     );
@@ -100,7 +98,6 @@ describe("writeAsrSettings", () => {
     writeAsrSettings(
       {
         ...DEFAULT_ASR_SETTINGS,
-        asrEnabled: false,
         silenceHangoverMs: 800,
         runtimeConfig: {
           ...DEFAULT_ASR_SETTINGS.runtimeConfig,
@@ -115,13 +112,11 @@ describe("writeAsrSettings", () => {
     );
 
     const loaded = readAsrSettings(storage);
-    expect(loaded.asrEnabled).toBe(false);
     expect(loaded.silenceHangoverMs).toBe(800);
     expect(loaded.runtimeConfig.decode.beamSearchEnabled).toBe(false);
     expect(loaded.runtimeConfig.decode.beamWidth).toBe(32);
 
     const snapshot = storage.snapshot();
-    expect(snapshot["toru.asr.enabled"]).toBe("0");
     expect(snapshot["toru.silence.hangover.ms"]).toBe("800");
     expect(snapshot["toru.asr.decode.beam.enabled"]).toBe("0");
     expect(snapshot["toru.asr.decode.beam.width"]).toBe("32");

--- a/src/asr/settings.ts
+++ b/src/asr/settings.ts
@@ -6,7 +6,6 @@ import {
 } from "./runtime-config";
 
 export interface AsrSettings {
-  asrEnabled: boolean;
   silenceRms: number;
   silencePeak: number;
   silenceHangoverMs: number;
@@ -23,7 +22,6 @@ interface StorageLike {
 }
 
 const STORAGE_KEYS = {
-  asrEnabled: "toru.asr.enabled",
   silenceRms: "toru.silence.rms",
   silencePeak: "toru.silence.peak",
   silenceHangoverMs: "toru.silence.hangover.ms",
@@ -37,7 +35,6 @@ const STORAGE_KEYS = {
 } as const;
 
 export const DEFAULT_ASR_SETTINGS: AsrSettings = {
-  asrEnabled: false,
   silenceRms: 0.0025,
   silencePeak: 0.012,
   silenceHangoverMs: 500,
@@ -75,10 +72,6 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function booleanWithFallback(value: unknown, fallback: boolean): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
 function numberWithFallback(
   value: unknown,
   fallback: number,
@@ -104,10 +97,6 @@ export function sanitizeAsrSettings(
   input: PartialAsrSettings | undefined,
 ): AsrSettings {
   return {
-    asrEnabled: booleanWithFallback(
-      input?.asrEnabled,
-      DEFAULT_ASR_SETTINGS.asrEnabled,
-    ),
     silenceRms: numberWithFallback(
       input?.silenceRms,
       DEFAULT_ASR_SETTINGS.silenceRms,
@@ -140,7 +129,6 @@ export function readAsrSettings(
   const target = storage ?? window.localStorage;
 
   return sanitizeAsrSettings({
-    asrEnabled: toBoolean(target.getItem(STORAGE_KEYS.asrEnabled)),
     silenceRms: toNumber(target.getItem(STORAGE_KEYS.silenceRms)),
     silencePeak: toNumber(target.getItem(STORAGE_KEYS.silencePeak)),
     silenceHangoverMs: toNumber(target.getItem(STORAGE_KEYS.silenceHangoverMs)),
@@ -172,7 +160,6 @@ export function writeAsrSettings(
   const target = storage ?? window.localStorage;
   const normalized = sanitizeAsrSettings(settings);
 
-  target.setItem(STORAGE_KEYS.asrEnabled, normalized.asrEnabled ? "1" : "0");
   target.setItem(STORAGE_KEYS.silenceRms, String(normalized.silenceRms));
   target.setItem(STORAGE_KEYS.silencePeak, String(normalized.silencePeak));
   target.setItem(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { decodeAudioFileToSamples } from "./audio/upload";
 import { AudioCapture } from "./audio/capture";
 import {
+  DEFAULT_ASR_SETTINGS,
   readAsrSettings,
   sanitizeAsrSettings,
   writeAsrSettings,
@@ -24,6 +25,10 @@ import {
   type PluginPlatform,
   type PluginPlatformState,
 } from "./plugins";
+import {
+  BUILTIN_MED_ASR_PLUGIN_ID,
+  type PluginManifest,
+} from "./plugins/contracts";
 import { getRecordingStore } from "./storage";
 
 const SAMPLE_RATE = 16000;
@@ -47,6 +52,7 @@ let settingsBtn: HTMLButtonElement;
 let uploadTranscriptBtn: HTMLButtonElement;
 let transcriptUploadInput: HTMLInputElement;
 let pluginListEl: HTMLElement;
+let asrPluginSettingsPanelEl: HTMLElement;
 let importPluginBtn: HTMLButtonElement;
 let importProgressEl: HTMLElement;
 let importProgressLabel: HTMLElement;
@@ -66,6 +72,7 @@ window.addEventListener("DOMContentLoaded", () => {
   uploadTranscriptBtn = mustBtn("uploadTranscriptBtn");
   transcriptUploadInput = mustFileInput("transcriptUploadInput");
   pluginListEl = mustEl("pluginList");
+  asrPluginSettingsPanelEl = mustEl("asrPluginSettingsPanel");
   importPluginBtn = mustBtn("importPluginBtn");
   importProgressEl = mustEl("importProgress");
   importProgressLabel = importProgressEl.querySelector(
@@ -78,15 +85,7 @@ window.addEventListener("DOMContentLoaded", () => {
   });
   asrSettingsController.populate(asrSettings);
 
-  const asrEnabledInput = document.getElementById(
-    "asrEnabled",
-  ) as HTMLInputElement;
-  const beamSearchInput = document.getElementById(
-    "asrBeamSearchEnabled",
-  ) as HTMLInputElement;
-  asrEnabledInput.addEventListener("change", () => {
-    void applyAsrEnabled(asrEnabledInput.checked);
-  });
+  const beamSearchInput = mustInput("asrBeamSearchEnabled");
   beamSearchInput.addEventListener("change", () => {
     void applyBeamSearch(beamSearchInput.checked);
   });
@@ -446,6 +445,13 @@ async function initializeStorage(): Promise<void> {
 async function initializePlugins(): Promise<void> {
   try {
     pluginState = await pluginPlatform.init();
+    if (!pluginState.activeAsr) {
+      const builtInAsrId = findBuiltInAsrPluginId();
+      if (builtInAsrId) {
+        await pluginPlatform.setActivePlugin("asr", builtInAsrId);
+        pluginState = await pluginPlatform.status();
+      }
+    }
     renderPluginStatus();
     if (currentRoute?.name === "recording") {
       ensureRecordingServicesLoaded();
@@ -458,6 +464,13 @@ async function initializePlugins(): Promise<void> {
 
 async function refreshPluginState(): Promise<void> {
   pluginState = await pluginPlatform.status();
+  if (!pluginState.activeAsr) {
+    const builtInAsrId = findBuiltInAsrPluginId();
+    if (builtInAsrId) {
+      await pluginPlatform.setActivePlugin("asr", builtInAsrId);
+      pluginState = await pluginPlatform.status();
+    }
+  }
   renderPluginStatus();
 }
 
@@ -466,6 +479,7 @@ function updateSettingsControls(): void {
 }
 
 function renderPluginStatus(): void {
+  syncDictationTuningForActiveAsr();
   recordingView.setTranscribeAvailable(isAsrTranscriptionEnabled());
   updateAsrLoadingIndicator();
   updateSettingsControls();
@@ -480,25 +494,78 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
+function formatPluginKindLabel(plugin: PluginManifest): string {
+  if (plugin.kind === "llm") {
+    return "Text Generation";
+  }
+  const language = parseAsrLanguage(plugin.metadata);
+  return language ? `Dictation (${language})` : "Dictation";
+}
+
+function parseAsrLanguage(metadata: PluginManifest["metadata"]): string | null {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+
+  const asRecord = metadata as Record<string, unknown>;
+  const direct = normalizeMetadataText(asRecord.language);
+  if (direct) {
+    return direct;
+  }
+
+  const runtimeConfig = asRecord.runtimeConfig;
+  if (!runtimeConfig || typeof runtimeConfig !== "object") {
+    return null;
+  }
+  const asRuntimeRecord = runtimeConfig as Record<string, unknown>;
+  return normalizeMetadataText(asRuntimeRecord.language);
+}
+
+function normalizeMetadataText(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const text = value.trim();
+  return text ? text : null;
+}
+
 function renderPluginList(): void {
-  // Scoped to LLM for now
-  const plugins = pluginState?.plugins.filter((p) => p.kind === "llm") ?? [];
-  const activeId = pluginState?.activeLlm?.pluginId ?? null;
+  const plugins =
+    pluginState?.plugins.sort((a, b) => {
+      if (a.kind !== b.kind) {
+        return a.kind.localeCompare(b.kind);
+      }
+      const aBuiltin = a.pluginId.startsWith("builtin.");
+      const bBuiltin = b.pluginId.startsWith("builtin.");
+      if (aBuiltin !== bBuiltin) {
+        return aBuiltin ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    }) ?? [];
+  const activeAsrId = pluginState?.activeAsr?.pluginId ?? null;
+  const activeLlmId = pluginState?.activeLlm?.pluginId ?? null;
   const llmState = pluginPlatform.getLlmLoadState();
-  const controlsDisabled =
-    pluginActivationTask !== null ||
-    llmState === "loading" ||
-    llmState === "unloading" ||
-    modelIdleUnloadTask !== null;
+  const asrState = pluginPlatform.getAsrLoadState();
+  let panelAttached = false;
 
   if (plugins.length === 0) {
     pluginListEl.innerHTML =
       '<p class="plugin-list-empty">No plugins imported yet.</p>';
+    asrPluginSettingsPanelEl.hidden = true;
     return;
   }
 
   pluginListEl.innerHTML = "";
   for (const plugin of plugins) {
+    const isBuiltIn = plugin.pluginId.startsWith("builtin.");
+    const activeId = plugin.kind === "asr" ? activeAsrId : activeLlmId;
+    const loadState = plugin.kind === "asr" ? asrState : llmState;
+    const controlsDisabled =
+      pluginActivationTask !== null ||
+      loadState === "loading" ||
+      loadState === "unloading" ||
+      modelIdleUnloadTask !== null;
+
     const row = document.createElement("div");
     row.className = "plugin-row";
 
@@ -512,7 +579,14 @@ function renderPluginList(): void {
 
     const meta = document.createElement("div");
     meta.className = "plugin-meta";
-    meta.textContent = plugin.sizeBytes ? formatFileSize(plugin.sizeBytes) : "";
+    const metaParts = [formatPluginKindLabel(plugin)];
+    if (isBuiltIn) {
+      metaParts.push("Built-in");
+    }
+    if (plugin.sizeBytes) {
+      metaParts.push(formatFileSize(plugin.sizeBytes));
+    }
+    meta.textContent = metaParts.join(" · ");
     info.appendChild(meta);
 
     row.appendChild(info);
@@ -527,30 +601,66 @@ function renderPluginList(): void {
     enabledInput.checked = plugin.pluginId === activeId;
     enabledInput.disabled = controlsDisabled;
     enabledInput.addEventListener("change", () => {
-      void setPluginEnabled(plugin.pluginId, enabledInput.checked);
+      void setPluginEnabled(plugin.kind, plugin.pluginId, enabledInput.checked);
     });
     const enabledText = document.createElement("span");
     enabledText.textContent = "Enabled";
     enabledLabel.append(enabledInput, enabledText);
     controls.appendChild(enabledLabel);
 
-    const deleteBtn = document.createElement("button");
-    deleteBtn.className = "plugin-delete-btn";
-    deleteBtn.textContent = "Delete";
-    deleteBtn.type = "button";
-    deleteBtn.disabled = controlsDisabled;
-    deleteBtn.addEventListener("click", () => {
-      void deletePlugin(plugin.pluginId, plugin.name);
-    });
-    controls.appendChild(deleteBtn);
+    if (!isBuiltIn) {
+      const deleteBtn = document.createElement("button");
+      deleteBtn.className = "plugin-delete-btn";
+      deleteBtn.textContent = "Delete";
+      deleteBtn.type = "button";
+      deleteBtn.disabled = controlsDisabled;
+      deleteBtn.addEventListener("click", () => {
+        void deletePlugin(plugin.pluginId, plugin.name);
+      });
+      controls.appendChild(deleteBtn);
+    }
 
     row.appendChild(controls);
 
+    if (plugin.kind === "asr" && plugin.pluginId === activeAsrId) {
+      const ownsSettings = ownsAsrSettingsPanel(
+        plugin.pluginId,
+        plugin.runtime,
+      );
+      if (!ownsSettings) {
+        pluginListEl.appendChild(row);
+        continue;
+      }
+      updateBeamSearchAvailabilityForRuntime(plugin.runtime);
+      asrPluginSettingsPanelEl.hidden = false;
+      row.appendChild(asrPluginSettingsPanelEl);
+      panelAttached = true;
+    }
+
     pluginListEl.appendChild(row);
+  }
+
+  if (!panelAttached) {
+    asrPluginSettingsPanelEl.hidden = true;
   }
 }
 
+function findBuiltInAsrPluginId(): string | null {
+  const medAsr = pluginState?.plugins.find(
+    (plugin) =>
+      plugin.kind === "asr" && plugin.pluginId === BUILTIN_MED_ASR_PLUGIN_ID,
+  );
+  if (medAsr) {
+    return medAsr.pluginId;
+  }
+  const fallback = pluginState?.plugins.find(
+    (plugin) => plugin.kind === "asr" && plugin.pluginId.startsWith("builtin."),
+  );
+  return fallback?.pluginId ?? null;
+}
+
 async function setPluginEnabled(
+  kind: "asr" | "llm",
   pluginId: string,
   enabled: boolean,
 ): Promise<void> {
@@ -558,27 +668,42 @@ async function setPluginEnabled(
     await pluginActivationTask;
   }
 
-  if (!enabled && pluginPlatform.isLlmBusy()) {
-    const proceed = window.confirm(
-      "A plugin is still processing a request. " +
-        "Press OK to stop now, or Cancel to wait.",
-    );
-    if (!proceed) {
-      renderPluginList();
-      return;
+  if (!enabled) {
+    const busy =
+      kind === "asr" ? pluginPlatform.isAsrBusy() : pluginPlatform.isLlmBusy();
+    if (busy) {
+      const proceed = window.confirm(
+        kind === "asr"
+          ? "ASR is still transcribing. Press OK to stop now, or Cancel to wait."
+          : "A plugin is still processing a request. Press OK to stop now, or Cancel to wait.",
+      );
+      if (!proceed) {
+        renderPluginList();
+        return;
+      }
     }
   }
 
-  const activeId = pluginState?.activeLlm?.pluginId ?? null;
-  const nextId = enabled ? pluginId : null;
+  const activeId =
+    kind === "asr"
+      ? (pluginState?.activeAsr?.pluginId ?? null)
+      : (pluginState?.activeLlm?.pluginId ?? null);
+  let nextId = enabled ? pluginId : null;
+  if (kind === "asr" && !enabled) {
+    nextId = findBuiltInAsrPluginId();
+  }
   if (activeId === nextId) {
+    renderPluginList();
     return;
   }
 
   pluginActivationTask = (async () => {
-    await pluginPlatform.setActivePlugin("llm", nextId);
+    await pluginPlatform.setActivePlugin(kind, nextId);
     await refreshPluginState();
-    if (isRecordingRouteOpen() && nextId) {
+    if (isRecordingRouteOpen() && nextId && kind === "asr") {
+      await setAsrLoaded(true).catch(() => undefined);
+    }
+    if (isRecordingRouteOpen() && nextId && kind === "llm") {
       await setLlmLoaded(true).catch(() => undefined);
     }
   })()
@@ -652,11 +777,7 @@ async function importPlugin(): Promise<void> {
       importProgressEl.hidden = true;
     }
     await refreshPluginState();
-    if (
-      imported.kind === "asr" &&
-      asrSettings.asrEnabled &&
-      currentRoute?.name === "recording"
-    ) {
+    if (imported.kind === "asr" && currentRoute?.name === "recording") {
       await setAsrLoaded(true).catch(() => undefined);
     }
   } catch (error) {
@@ -772,7 +893,7 @@ async function unloadModelsAfterIdle(): Promise<void> {
 
 function ensureRecordingServicesLoaded(): void {
   clearModelUnloadTimer();
-  if (asrSettings.asrEnabled && pluginState?.features.transcription) {
+  if (pluginState?.features.transcription) {
     void setAsrLoaded(true).catch((error) =>
       reportUnexpectedError(error, "ASR load failed"),
     );
@@ -784,23 +905,49 @@ function ensureRecordingServicesLoaded(): void {
   }
 }
 
-async function applyAsrEnabled(enabled: boolean): Promise<void> {
-  asrSettings.asrEnabled = enabled;
-  try {
-    writeAsrSettings(asrSettings);
-  } catch {
-    // Best-effort persist; value is already applied in memory
+function updateBeamSearchAvailabilityForRuntime(runtime: string): void {
+  const beamSearchInput = document.getElementById("asrBeamSearchEnabled");
+  const beamMeta = document.getElementById("beamSearchMeta");
+  if (!(beamSearchInput instanceof HTMLInputElement)) {
+    return;
   }
 
-  if (!enabled) {
-    await setAsrLoaded(false).catch(() => undefined);
-  } else if (isRecordingRouteOpen() && pluginState?.features.transcription) {
-    void setAsrLoaded(true).catch((error) =>
-      reportUnexpectedError(error, "ASR load failed"),
-    );
+  const beamSupported = runtime === "ort-ctc";
+  beamSearchInput.disabled = !beamSupported;
+  if (!beamSupported) {
+    beamSearchInput.checked = false;
+    if (asrSettings.runtimeConfig.decode.beamSearchEnabled) {
+      asrSettings.runtimeConfig.decode.beamSearchEnabled = false;
+      try {
+        writeAsrSettings(asrSettings);
+      } catch {
+        // Best-effort persist
+      }
+    }
   }
-  recordingView.setTranscribeAvailable(isAsrTranscriptionEnabled());
-  updateAsrLoadingIndicator();
+
+  if (beamMeta instanceof HTMLElement) {
+    beamMeta.textContent = beamSupported
+      ? "Improves quality but uses more memory"
+      : "Unavailable for current ASR plugin";
+  }
+}
+
+function ownsAsrSettingsPanel(pluginId: string, runtime: string): boolean {
+  return pluginId === BUILTIN_MED_ASR_PLUGIN_ID && runtime === "ort-ctc";
+}
+
+function syncDictationTuningForActiveAsr(): void {
+  const activeAsr = pluginState?.activeAsr;
+  const tuningSource =
+    activeAsr && ownsAsrSettingsPanel(activeAsr.pluginId, activeAsr.runtime)
+      ? asrSettings
+      : DEFAULT_ASR_SETTINGS;
+  dictation.setVadSettings({
+    silenceRms: tuningSource.silenceRms,
+    silencePeak: tuningSource.silencePeak,
+    silenceHangoverMs: tuningSource.silenceHangoverMs,
+  });
 }
 
 async function applyBeamSearch(enabled: boolean): Promise<void> {
@@ -814,7 +961,7 @@ async function applyBeamSearch(enabled: boolean): Promise<void> {
   // Beam search config is baked into the worker at load time, so cycle ASR
   if (pluginPlatform.isAsrReady()) {
     await setAsrLoaded(false).catch(() => undefined);
-    if (asrSettings.asrEnabled && isRecordingRouteOpen()) {
+    if (isRecordingRouteOpen() && pluginState?.features.transcription) {
       void setAsrLoaded(true).catch((error) =>
         reportUnexpectedError(error, "ASR load failed"),
       );
@@ -904,7 +1051,7 @@ async function transcribeUploadedFile(file: File): Promise<void> {
 }
 
 function isAsrTranscriptionEnabled(): boolean {
-  return asrSettings.asrEnabled && Boolean(pluginState?.features.transcription);
+  return Boolean(pluginState?.features.transcription);
 }
 
 function isRecordingRouteOpen(): boolean {

--- a/src/plugins/contracts.test.ts
+++ b/src/plugins/contracts.test.ts
@@ -55,7 +55,7 @@ describe("plugin contracts", () => {
     const manifest: PluginManifest = {
       ...BUILTIN_ORT_ASR_PLUGIN,
       pluginId: "test.asr.whisper",
-      runtime: "ort-whisper",
+      runtime: "whisper",
       metadata: {},
     };
 

--- a/src/plugins/contracts.ts
+++ b/src/plugins/contracts.ts
@@ -29,9 +29,11 @@ export interface PluginValidationIssue {
   message: string;
 }
 
+export const BUILTIN_MED_ASR_PLUGIN_ID = "builtin.asr.ort.medasr";
+
 export const BUILTIN_ORT_ASR_PLUGIN: PluginManifest = {
-  pluginId: "builtin.asr.ort.medasr",
-  name: "Built-in Medical ASR",
+  pluginId: BUILTIN_MED_ASR_PLUGIN_ID,
+  name: "Google MedASR",
   version: "1.0.0",
   kind: "asr",
   runtime: "ort-ctc",
@@ -39,6 +41,7 @@ export const BUILTIN_ORT_ASR_PLUGIN: PluginManifest = {
   hash: "05c1907f53d9dea3db23092e4d730f011ee400b3fb282d6af8443276dfb9d270",
   modelFamily: "medasr_lasr",
   metadata: {
+    language: "en",
     vocabPath: "models/medasr_lasr_vocab.json",
     vocabHash:
       "631bd152b5beca9a74d21bd1c3ff53fecf63d10d11aae72e491cacdfbf69a756",
@@ -56,7 +59,7 @@ const ID_RE = /^[A-Za-z0-9._-]{3,128}$/;
 
 function isSupportedRuntime(kind: PluginKind, runtime: string): boolean {
   if (kind === "asr") {
-    return runtime === "ort-ctc" || runtime === "ort-whisper";
+    return runtime === "ort-ctc" || runtime === "whisper";
   }
   return runtime === "llamafile";
 }

--- a/src/plugins/runtime-adapter.test.ts
+++ b/src/plugins/runtime-adapter.test.ts
@@ -54,11 +54,49 @@ describe("runtime adapter", () => {
         {
           ...BUILTIN_ORT_ASR_PLUGIN,
           pluginId: "bad.asr.runtime-whisper-web",
-          runtime: "ort-whisper",
+          runtime: "whisper",
           metadata: {},
         },
         OPTIONS,
       ),
     ).toThrowError(/only supported in native desktop mode/);
+  });
+
+  it("applies custom runtime config only to built-in Med ASR", () => {
+    const tunedOptions = {
+      ...OPTIONS,
+      asrRuntimeConfig: {
+        ortThreads: 2,
+        decode: {
+          beamSearchEnabled: true,
+          beamWidth: 16,
+          lmAlpha: 0.9,
+          lmBeta: 2.1,
+          minTokenLogp: -3,
+          beamPruneLogp: -7,
+        },
+      },
+    };
+
+    const builtInAdapter = createRuntimeAdapter(
+      BUILTIN_ORT_ASR_PLUGIN,
+      tunedOptions,
+    ) as unknown as { asrRuntimeConfig: typeof tunedOptions.asrRuntimeConfig };
+    expect(builtInAdapter.asrRuntimeConfig.decode.beamSearchEnabled).toBe(true);
+    expect(builtInAdapter.asrRuntimeConfig.ortThreads).toBe(2);
+
+    const importedAdapter = createRuntimeAdapter(
+      {
+        ...BUILTIN_ORT_ASR_PLUGIN,
+        pluginId: "import.asr.ort.custom",
+      },
+      tunedOptions,
+    ) as unknown as { asrRuntimeConfig: typeof tunedOptions.asrRuntimeConfig };
+    expect(importedAdapter.asrRuntimeConfig.decode.beamSearchEnabled).toBe(
+      DEFAULT_ASR_RUNTIME_CONFIG.decode.beamSearchEnabled,
+    );
+    expect(importedAdapter.asrRuntimeConfig.ortThreads).toBe(
+      DEFAULT_ASR_RUNTIME_CONFIG.ortThreads,
+    );
   });
 });

--- a/src/plugins/runtime-adapter.ts
+++ b/src/plugins/runtime-adapter.ts
@@ -2,7 +2,8 @@ import { convertFileSrc, invoke, isTauri } from "@tauri-apps/api/core";
 
 import { AsrClient, type AsrClientEvents } from "../asr/client";
 import type { AsrRuntimeConfig } from "../asr-messages";
-import type { PluginManifest } from "./contracts";
+import { DEFAULT_ASR_RUNTIME_CONFIG } from "../asr/runtime-config";
+import { BUILTIN_MED_ASR_PLUGIN_ID, type PluginManifest } from "./contracts";
 
 export interface RuntimeHealth {
   ready: boolean;
@@ -76,10 +77,7 @@ export function createRuntimeAdapter(
 ): RuntimeAdapter {
   switch (manifest.kind) {
     case "asr": {
-      if (
-        manifest.runtime !== "ort-ctc" &&
-        manifest.runtime !== "ort-whisper"
-      ) {
+      if (manifest.runtime !== "ort-ctc" && manifest.runtime !== "whisper") {
         throw new Error(
           `Unsupported ASR runtime "${manifest.runtime}" for ${manifest.pluginId}`,
         );
@@ -107,7 +105,7 @@ export function createRuntimeAdapter(
         options.ortDir,
         options.appDataDir,
         options.appOrigin,
-        options.asrRuntimeConfig,
+        resolveAsrRuntimeConfig(manifest, options.asrRuntimeConfig),
       );
     }
     case "llm":
@@ -122,6 +120,26 @@ export function createRuntimeAdapter(
         `Unsupported plugin kind "${manifest.kind}" for ${manifest.pluginId}`,
       );
   }
+}
+
+function resolveAsrRuntimeConfig(
+  manifest: PluginManifest,
+  runtimeConfig: AsrRuntimeConfig,
+): AsrRuntimeConfig {
+  if (manifest.pluginId === BUILTIN_MED_ASR_PLUGIN_ID) {
+    return runtimeConfig;
+  }
+  return {
+    ortThreads: DEFAULT_ASR_RUNTIME_CONFIG.ortThreads,
+    decode: {
+      beamSearchEnabled: DEFAULT_ASR_RUNTIME_CONFIG.decode.beamSearchEnabled,
+      beamWidth: DEFAULT_ASR_RUNTIME_CONFIG.decode.beamWidth,
+      lmAlpha: DEFAULT_ASR_RUNTIME_CONFIG.decode.lmAlpha,
+      lmBeta: DEFAULT_ASR_RUNTIME_CONFIG.decode.lmBeta,
+      minTokenLogp: DEFAULT_ASR_RUNTIME_CONFIG.decode.minTokenLogp,
+      beamPruneLogp: DEFAULT_ASR_RUNTIME_CONFIG.decode.beamPruneLogp,
+    },
+  };
 }
 
 class OrtRuntimeAdapter implements RuntimeAdapter {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,4 @@
-/* MedGemma Mobile - Design System */
+/* Dr. Toru - Design System */
 
 * {
   margin: 0;
@@ -1321,6 +1321,7 @@ body {
 #screen-settings .plugin-row {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-3);
   padding: var(--space-3);
   border: 1px solid var(--border);
@@ -1386,6 +1387,22 @@ body {
 #screen-settings .plugin-row .plugin-delete-btn:hover {
   color: var(--text-primary);
   border-color: var(--text-secondary);
+}
+
+#screen-settings .plugin-settings-panel {
+  flex-basis: 100%;
+  width: 100%;
+  margin-top: var(--space-2);
+}
+
+#screen-settings .plugin-settings-panel .plugin-row {
+  background: var(--bg-secondary);
+  border-style: dashed;
+}
+
+#screen-settings .plugin-settings-panel .settings-advanced {
+  margin-top: var(--space-2);
+  margin-bottom: 0;
 }
 
 #screen-settings .import-progress {


### PR DESCRIPTION
Summary
- hide plugin settings when a plugin is disabled, rename ASR and LLM display labels to “Dictation”/“Text Generation,” and adjust related copy (Beam Search → Enhanced Dictation, updated tooltip text and labels)
- show MedASR metadata details (including `en` language) and remove the redundant “built-in” label on its enabled button
- clean up dead ASR settings code, deduplicate shared Rust helpers, and refresh the stale CSS comment

Testing
- Not run (not requested)