### PR TITLE
fix: chunk uploaded audio to prevent transcript truncation

### DIFF
--- a/docs/plans/2026-02-22-fix-kotoba-upload-drops-transcript-chunks-plan.md
+++ b/docs/plans/2026-02-22-fix-kotoba-upload-drops-transcript-chunks-plan.md
@@ -1,0 +1,199 @@
+---
+title: "fix: Kotoba upload drops transcript chunks"
+type: fix
+date: 2026-02-22
+---
+
+# fix: Kotoba upload drops transcript chunks
+
+## Overview
+
+When uploading an audio file for transcription using a custom imported kotoba
+(Whisper) ASR plugin, only a partial transcript is produced — the output cuts
+off early. This always reproduces. Live dictation (mic recording) works fine
+because VAD segments are small enough to avoid the underlying issue.
+
+## Problem Statement
+
+The upload transcription path sends the **entire decoded audio** as a single
+`Float32Array` through `pluginPlatform.transcribe(samples)`. For native ASR
+plugins (anything that isn't the built-in MedASR/ort-ctc), this routes through
+`NativeAsrRuntimeAdapter.execute()`, which does:
+
+```typescript
+// src/plugins/runtime-adapter.ts:241-244
+return invoke<RuntimeExecuteResult>("plugin_asr_transcribe", {
+  pluginId: this.pluginId,
+  samples: Array.from(request.samples),  // ← converts Float32Array to number[]
+});
+```
+
+**Two compounding problems:**
+
+### 1. Massive JSON payload via Tauri IPC
+
+`Array.from(Float32Array)` produces a JavaScript `number[]` that Tauri
+serializes to JSON. A 5-minute audio file at 16kHz = 4,800,000 float samples.
+Each float serializes to ~10-15 JSON characters, producing **~50-70MB of JSON**
+for the IPC message. Tauri's JSON-based `invoke()` has practical limits on
+message size, and large payloads can be silently truncated, causing the Rust
+side to receive fewer samples than expected.
+
+### 2. No chunking for uploaded files
+
+Live dictation naturally avoids this because the VAD segmenter breaks audio
+into small chunks (a few seconds each), each well within IPC limits. But the
+upload path sends everything at once — there's no chunking layer for uploaded
+files.
+
+**Why built-in MedASR is unaffected:** It uses `OrtRuntimeAdapter` which
+passes samples directly to the web worker via `postMessage()` with
+`ArrayBuffer` transfer — binary, no JSON serialization, no size limits.
+
+## Root Cause
+
+```
+Upload file
+  → decodeAudioFileToSamples() → full Float32Array (millions of samples)
+  → pluginPlatform.transcribe(samples)
+  → NativeAsrRuntimeAdapter.execute()
+  → Array.from(samples)  ← creates massive number[]
+  → invoke("plugin_asr_transcribe", { samples: [...] })
+  → Tauri JSON serializes ~50MB+ of numbers
+  → Rust receives truncated Vec<f32>
+  → Whisper transcribes only what it received → partial transcript
+```
+
+## Proposed Solution
+
+**Chunk uploaded audio on the frontend before sending to the ASR runtime.**
+This mirrors what live dictation already does (VAD segmenter → small chunks →
+transcribe each → merge results) but with fixed-size chunks instead of
+VAD segments.
+
+This approach:
+- Fixes the IPC size issue (each chunk is small)
+- Works for both native and web worker ASR runtimes
+- Reuses the existing `mergeChunkText()` overlap-merge logic
+- Keeps the fix entirely in TypeScript (no Rust changes)
+- Matches the benchmark tool's proven chunking strategy
+
+### Implementation
+
+#### Phase 1: Extract chunk utilities
+
+Create `src/audio/chunk.ts` with two functions extracted/adapted from
+`DictationController` and the benchmark tool:
+
+```typescript
+// src/audio/chunk.ts
+
+const DEFAULT_CHUNK_SECS = 20;
+const DEFAULT_STRIDE_SECS = 2;
+
+/**
+ * Split audio samples into overlapping chunks for sequential transcription.
+ * Uses fixed-size windows (not VAD) since we have the complete audio upfront.
+ */
+export function chunkAudio(
+  samples: Float32Array,
+  sampleRate: number,
+  chunkSecs = DEFAULT_CHUNK_SECS,
+  strideSecs = DEFAULT_STRIDE_SECS,
+): Float32Array[] {
+  const chunkLen = Math.floor(chunkSecs * sampleRate);
+  if (chunkLen >= samples.length) {
+    return [samples];
+  }
+  const strideLen = Math.floor(strideSecs * sampleRate);
+  const stepLen = chunkLen - strideLen;
+  const chunks: Float32Array[] = [];
+  let offset = 0;
+  while (offset < samples.length) {
+    const end = Math.min(offset + chunkLen, samples.length);
+    chunks.push(samples.subarray(offset, end));
+    if (end >= samples.length) break;
+    offset += stepLen;
+  }
+  return chunks;
+}
+```
+
+Chunk sizes: **20s chunks with 2s stride** — matches the benchmark's
+best-performing config for Whisper models, and keeps each IPC payload under
+~2.5MB of JSON (manageable).
+
+#### Phase 2: Modify `transcribeUploadedFile` to chunk and merge
+
+In `src/main.ts`, change the upload transcription path from a single call to
+a chunk-iterate-merge loop:
+
+```typescript
+// src/main.ts — transcribeUploadedFile (modified)
+
+import { chunkAudio } from "./audio/chunk";
+import { mergeChunkText } from "./app/dictation-controller";
+
+// ... inside transcribeUploadedFile:
+const samples = await decodeAudioFileToSamples(file, SAMPLE_RATE);
+const chunks = chunkAudio(samples, SAMPLE_RATE);
+
+let transcript = "";
+for (const chunk of chunks) {
+  const text = await pluginPlatform.transcribe(chunk);
+  transcript = mergeChunkText(transcript, text);
+}
+
+await recordingView.onRecordingComplete(transcript);
+```
+
+#### Phase 3: Export `mergeChunkText` from dictation-controller
+
+`mergeChunkText` is already a standalone function in
+`src/app/dictation-controller.ts:281`. It just needs to be exported (it
+already is — `export function mergeChunkText`). No changes needed here.
+
+### Files to change
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `src/audio/chunk.ts` | `chunkAudio()` utility |
+| Modify | `src/main.ts` | Chunk uploaded audio before transcribing |
+| Test | `src/audio/chunk.test.ts` | Unit tests for chunking logic |
+
+## Acceptance Criteria
+
+- [ ] Uploading a 5+ minute audio file with kotoba plugin produces a complete
+      transcript (not truncated)
+- [x] Short audio files (< 20s) still work correctly (single chunk, no
+      overhead)
+- [x] `chunkAudio()` produces overlapping windows with correct boundaries
+- [x] `mergeChunkText()` properly deduplicates overlap regions between chunks
+- [ ] Built-in MedASR upload transcription still works (regression check)
+- [ ] Live dictation still works normally (no changes to that path)
+- [x] Unit tests cover edge cases: empty audio, exactly chunk-sized audio,
+      audio shorter than one chunk, audio with remainder less than stride
+
+## Technical Considerations
+
+- **Chunk size trade-off:** Larger chunks = fewer IPC calls + better context
+  for the model, but larger JSON payloads. 20s at 16kHz = 320,000 floats ≈
+  2.5MB JSON — safe for Tauri IPC. The benchmark tool shows 20s/2s produces
+  good WER scores.
+- **Future optimization:** If IPC size remains a concern, a more robust fix
+  would be writing samples to a temp file and passing the path to Rust.
+  However, chunking is the simpler fix and also improves transcript quality
+  for long files (Whisper's attention degrades on very long sequences even
+  though whisper.cpp does internal 30s windowing).
+- **No Rust changes needed.** The Rust side already handles `Vec<f32>` of
+  any size; it's the JSON serialization layer that truncates.
+
+## References
+
+- Upload entry point: `src/main.ts:1047` (`transcribeUploadedFile`)
+- Native ASR adapter: `src/plugins/runtime-adapter.ts:235` (`NativeAsrRuntimeAdapter.execute`)
+- Benchmark chunking: `src-tauri/src/bin/benchmark_asr.rs:179` (`chunk_audio`)
+- Merge logic: `src/app/dictation-controller.ts:281` (`mergeChunkText`)
+- Audio decode: `src/audio/upload.ts:1` (`decodeAudioFileToSamples`)
+- [Whisper 30s context window](https://github.com/ggml-org/whisper.cpp/discussions/206)
+- [Whisper long-form transcription](https://medium.com/@yoad/whisper-long-form-transcription-1924c94a9b86)

--- a/src/audio/chunk.test.ts
+++ b/src/audio/chunk.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { chunkAudio } from "./chunk";
+
+describe("chunkAudio", () => {
+  it("returns empty array for empty audio", () => {
+    expect(chunkAudio(new Float32Array(), 16000)).toEqual([]);
+  });
+
+  it("returns single chunk when audio is shorter than chunk length", () => {
+    const samples = new Float32Array(16000 * 10); // 10 seconds
+    const chunks = chunkAudio(samples, 16000, 20, 2);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(samples); // same reference (subarray of full buffer)
+  });
+
+  it("returns single chunk when audio is exactly chunk length", () => {
+    const samples = new Float32Array(16000 * 20); // exactly 20 seconds
+    const chunks = chunkAudio(samples, 16000, 20, 2);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(samples);
+  });
+
+  it("chunks audio with correct overlap", () => {
+    // 40 seconds of audio at 16kHz with 20s chunks and 2s stride
+    const sampleRate = 16000;
+    const samples = new Float32Array(sampleRate * 40);
+    // Fill with sequential values for verification
+    for (let i = 0; i < samples.length; i++) {
+      samples[i] = i;
+    }
+
+    const chunks = chunkAudio(samples, sampleRate, 20, 2);
+
+    // Step = 20 - 2 = 18 seconds. Offsets: 0, 18s, 36s.
+    // Chunk 0: [0, 20s), chunk 1: [18s, 38s), chunk 2: [36s, 40s)
+    expect(chunks).toHaveLength(3);
+
+    // First chunk: 0 to 20s
+    expect(chunks[0].length).toBe(sampleRate * 20);
+    expect(chunks[0][0]).toBe(0);
+
+    // Second chunk: 18s to 38s
+    expect(chunks[1].length).toBe(sampleRate * 20);
+    expect(chunks[1][0]).toBe(sampleRate * 18);
+
+    // Third chunk: 36s to 40s (remainder)
+    expect(chunks[2].length).toBe(sampleRate * 4);
+    expect(chunks[2][0]).toBe(sampleRate * 36);
+  });
+
+  it("handles audio just over one chunk length", () => {
+    const sampleRate = 100; // small rate for easy math
+    const samples = new Float32Array(2100); // 21 seconds at 100Hz
+    const chunks = chunkAudio(samples, sampleRate, 20, 2);
+
+    // Step = 18s = 1800 samples. Chunk 0: [0, 2000), chunk 1: [1800, 2100)
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].length).toBe(2000);
+    expect(chunks[1].length).toBe(300); // 2100 - 1800
+  });
+
+  it("returns views into the original buffer (no copies)", () => {
+    const samples = new Float32Array(16000 * 25);
+    const chunks = chunkAudio(samples, 16000, 20, 2);
+    expect(chunks[0].buffer).toBe(samples.buffer);
+    expect(chunks[1].buffer).toBe(samples.buffer);
+  });
+
+  it("uses default parameters when not specified", () => {
+    // 60 seconds of audio - should produce multiple chunks with defaults (20s/2s)
+    const samples = new Float32Array(16000 * 60);
+    const chunks = chunkAudio(samples);
+    // Step = 18s. Offsets: 0, 18, 36, 54. Last chunk starts at 54s, extends to 60s.
+    expect(chunks).toHaveLength(4);
+  });
+});

--- a/src/audio/chunk.ts
+++ b/src/audio/chunk.ts
@@ -1,0 +1,41 @@
+const SAMPLE_RATE = 16000;
+const DEFAULT_CHUNK_SECS = 20;
+const DEFAULT_STRIDE_SECS = 2;
+
+/**
+ * Split audio samples into overlapping chunks for sequential transcription.
+ * Uses fixed-size windows since we have the complete audio upfront.
+ *
+ * Returns subarrays (views into the original buffer, no copies).
+ */
+export function chunkAudio(
+  samples: Float32Array,
+  sampleRate: number = SAMPLE_RATE,
+  chunkSecs: number = DEFAULT_CHUNK_SECS,
+  strideSecs: number = DEFAULT_STRIDE_SECS,
+): Float32Array[] {
+  if (samples.length === 0) {
+    return [];
+  }
+
+  const chunkLen = Math.floor(chunkSecs * sampleRate);
+  if (chunkLen >= samples.length) {
+    return [samples];
+  }
+
+  const strideLen = Math.floor(strideSecs * sampleRate);
+  const stepLen = chunkLen - strideLen;
+  const chunks: Float32Array[] = [];
+  let offset = 0;
+
+  while (offset < samples.length) {
+    const end = Math.min(offset + chunkLen, samples.length);
+    chunks.push(samples.subarray(offset, end));
+    if (end >= samples.length) {
+      break;
+    }
+    offset += stepLen;
+  }
+
+  return chunks;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { chunkAudio } from "./audio/chunk";
 import { decodeAudioFileToSamples } from "./audio/upload";
 import { AudioCapture } from "./audio/capture";
 import {
@@ -8,7 +9,10 @@ import {
   type AsrSettings,
 } from "./asr/settings";
 import { AsrSettingsController } from "./app/asr-settings-controller";
-import { DictationController } from "./app/dictation-controller";
+import {
+  DictationController,
+  mergeChunkText,
+} from "./app/dictation-controller";
 import { ListController, fireRecordingsChanged } from "./app/list";
 import { RecordingService } from "./app/recording-service";
 import { RecordingViewController } from "./app/recording-view-controller";
@@ -1050,7 +1054,12 @@ async function transcribeUploadedFile(file: File): Promise<void> {
       return;
     }
 
-    const transcript = await pluginPlatform.transcribe(samples);
+    const chunks = chunkAudio(samples, SAMPLE_RATE);
+    let transcript = "";
+    for (const chunk of chunks) {
+      const text = await pluginPlatform.transcribe(chunk);
+      transcript = mergeChunkText(transcript, text);
+    }
     await recordingView.onRecordingComplete(transcript);
   } catch (error) {
     reportUnexpectedError(error, `Failed to transcribe file "${file.name}"`);


### PR DESCRIPTION
## Summary

- Uploaded audio files sent through native ASR plugins (kotoba/Whisper) were silently truncated because the entire `Float32Array` was converted to a JSON `number[]` for Tauri IPC, producing payloads too large for reliable serialization (~50-70MB for a 5-minute file)
- Splits uploaded audio into 20s overlapping chunks (2s stride) before transcribing each chunk, then merges results using the existing `mergeChunkText()` overlap deduplication
- Live dictation is unaffected (VAD already produces small segments); built-in MedASR is unaffected (uses binary `postMessage` transfer, not JSON)

## Changes

| File | Change |
|------|--------|
| `src/audio/chunk.ts` | New `chunkAudio()` utility — fixed-size overlapping windows via `subarray` (zero-copy) |
| `src/audio/chunk.test.ts` | 7 unit tests covering edge cases |
| `src/main.ts` | `transcribeUploadedFile` now chunks audio and merges results |
| `docs/plans/...` | Plan document |

## Test plan

- [x] All 128 unit tests pass
- [ ] Upload a 5+ minute audio file with kotoba plugin → verify complete transcript
- [ ] Upload a short (< 20s) audio file → verify single-chunk path still works
- [ ] Run live dictation → verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)